### PR TITLE
Turn an Eunit test into a test generator

### DIFF
--- a/test/utest/src/cuter_tests.erl
+++ b/test/utest/src/cuter_tests.erl
@@ -40,8 +40,8 @@ find_bugs({Fn, Inp, Depth, Bugs}) ->
 
 -define(TIMEOUT_RMT, 40000).
 
--spec run_multiple_test() -> {'timeout', ?TIMEOUT_RMT, fun(() -> nonempty_list())}.
-run_multiple_test() ->
+-spec run_multiple_test_() -> {'timeout', ?TIMEOUT_RMT, fun(() -> nonempty_list())}.
+run_multiple_test_() ->
   Fn = fun() ->
     Seeds = [
       {lists, nth, [3, [1,2,3]], 15},


### PR DESCRIPTION
This change, done to avoid some timeouts we were experiencing while
running the test suite at some point, was the only difference of
branch new-z3 that I could see.

See also the discussion on commit https://github.com/cuter-testing/cuter/commit/1510a049227e545db9521974aa92ce369c041fa6.