### PR TITLE
Force function domains to contain at least one element

### DIFF
--- a/priv/cuter_smt.py
+++ b/priv/cuter_smt.py
@@ -374,12 +374,21 @@ class ErlangSMT(cgs.AbstractErlangSolver):
 			par_spec = cc.get_parameters_from_complete_fun(spec)
 			ret_spec = cc.get_rettype_from_fun(spec)
 			name = self.fun_rec_flist(par_spec, ret_spec)
-			return ["and", ["is-fun", var], ["=", ["fa", ["fv", var]], build_int(len(par_spec))], [name, ["fm", ["fv", var]]]]
+			return ["and",
+				["is-fun", var],
+				["=", ["fa", ["fv", var]], build_int(len(par_spec))],
+				[name, ["fm", ["fv", var]]],
+				["not", ["=", ["fm", ["fv", var]], "fn"]]
+			]
 		elif cc.is_type_generic_fun(spec):
 			par_spec = None
 			ret_spec = cc.get_rettype_from_fun(spec)
 			name = self.fun_rec_flist(par_spec, ret_spec)
-			return ["and", ["is-fun", var], [name, ["fm", ["fv", var]]]]
+			return ["and",
+				["is-fun", var],
+				[name, ["fm", ["fv", var]]],
+				["not", ["=", ["fm", ["fv", var]], "fn"]]
+			]
 		elif cc.is_type_atomlit(spec):
 			return ["=", var, self.decode(cc.get_literal_from_atomlit(spec))]
 		elif cc.is_type_integerlit(spec):

--- a/test/ftest/src/funs.erl
+++ b/test/ftest/src/funs.erl
@@ -1,7 +1,7 @@
 -module(funs).
 -export([f1/1, f2/3, f3/3, f41/3, f42/3, f5/4, f6/1, f7/2, f8/2,
          f91/3, f92/2, f10/1, f11/3, f12/1, f1ws/1, f2ws/3, f3ws/3,
-         f5ws/4, f1hs/1, f13a/2, f13b/2, f14/2]).
+         f5ws/4, f1hs/1, f13a/2, f13b/2, f14/2, mf/3]).
 
 -spec f1(fun((integer()) -> integer())) -> ok.
 f1(F) ->
@@ -233,3 +233,10 @@ f14(F, L) ->
     [1, 2, 3] -> error(bug);
     _ -> ok
   end.
+
+-spec mf(fun((T) -> T), fun((T) -> boolean()), [T]) -> ok.
+mf(F, P, L) ->
+   case lists:map(F, lists:filter(P, L)) =:= lists:filter(P, lists:map(F, L)) of
+     true -> ok;
+     false -> error(mf_prop_fails)
+   end.

--- a/test/ftests.json
+++ b/test/ftests.json
@@ -1183,6 +1183,20 @@
             "arity": 1,
             "xopts": "--z3-timeout 1",
             "skip": false
+        },
+        {
+            "module": "funs",
+            "function": "mf",
+            "args": "[fun(X) -> X end, fun(_) -> true end,[]]",
+            "depth": "5",
+            "errors": true,
+            "arity": 3,
+            "nondeterministic": true,
+            "solutions": [
+                "type($2((0,))) == type(True)",
+                "[$1((x,)) for x in $3 if $2((x,))] != [z for z in [$1((y,)) for y in $3] if $2((z,))]"
+            ],
+            "skip": false
         }
     ]
 }


### PR DESCRIPTION
The pointwise definition of a function in the solver's logic allows a
function to have an empty domain set, which results in a total function
with an undefined value.
Forcing all functions to be defined for at least one point ensures that
there are no undefined values in the codomain.