### PR TITLE
Move funs in arguments to separate variables to avoid illegal patterns.

### DIFF
--- a/src/cuter_lib.erl
+++ b/src/cuter_lib.erl
@@ -209,7 +209,7 @@ compile_lambda(T) ->
 compile_lambda_h(#?lambda{arity = Arity, kvs = KVs, default = Default}) ->
   %% TODO Check if the parameters is a lambda, in case of recursion.
   %% TODO Also compile lambdas in maps.
-  CompiledKVs = [{K, compile_lambda_h(V)} || {K, V} <- KVs],
+  CompiledKVs = [{compile_lambda_h(K), compile_lambda_h(V)} || {K, V} <- KVs],
   CompiledDefault = compile_lambda_h(Default),
   Dict = dict:from_list(CompiledKVs),
   Lookup = fun(As) -> lookup_args(As, Dict, CompiledDefault) end,

--- a/src/cuter_pp.erl
+++ b/src/cuter_pp.erl
@@ -721,8 +721,10 @@ pp_execution_status_fully_verbose({internal_error, {Type, Node, Why}}) ->
 pp_input_minimal([], {M, F, _}) ->
   io:format(standard_error, "\033[01;31m~p:~p()\033[00m~n", [M, F]);
 pp_input_minimal(Input, {M, F, _}) ->
-  io:format(standard_error, "\033[01;31m~p:~p(\033[00m", [M, F]),
-  S = pp_arguments(Input),
+  FLs = preprocess_input(Input),
+  S = pp_arguments(Input, FLs),
+  As = pp_assignments(FLs),
+  io:format(standard_error, "\033[01;31m~s~p:~p(\033[00m", [As, M, F]),
   io:format(standard_error, "\033[01;31m~s)\033[00m~n", [S]).
 
 -spec pp_input_verbose(cuter:input(), mfa()) -> ok.
@@ -744,9 +746,6 @@ pp_assignments(FLs) ->
   PP_Fn = fun(Fn) -> pp_argument(Fn, proplists:delete(Fn, FLs)) end,
   Ss = [io_lib:format("~s = ~s, ", [[L, $0], PP_Fn(Fn)]) || {Fn, L} <- FLs],
   string:join(Ss, "").
-
-pp_arguments(Args) ->
-  pp_arguments(Args, []).
 
 pp_arguments(Args, FLs) ->
   string:join([pp_argument(A, FLs) || A <- Args], ", ").
@@ -997,7 +996,10 @@ pp_erroneous_inputs_h([{Mfa, Errors}|Rest], N) ->
 pp_erroneous_inputs_mfa([], _MFA, N) ->
   N;
 pp_erroneous_inputs_mfa([I|Is], {M, F, _}=MFA, N) ->
-  io:format("~n#~w \033[00;31m~p:~p(~s)\033[00m", [N, M, F, pp_arguments(I)]),
+  FLs = preprocess_input(I),
+  S = pp_arguments(I, FLs),
+  As = pp_assignments(FLs),
+  io:format("~n#~w \033[00;31m~s~p:~p(~s)\033[00m", [N, As, M, F, S]),
   pp_erroneous_inputs_mfa(Is, MFA, N + 1).
 
 %% ----------------------------------------------------------------------------

--- a/src/cuter_pp.erl
+++ b/src/cuter_pp.erl
@@ -777,6 +777,9 @@ pp_argument(Arg) ->
   pp_argument(Arg, []).
 
 pp_argument(Arg, FLs) ->
+  pp_argument(Arg, FLs, false).
+
+pp_argument(Arg, FLs, IsP) ->
   case cuter_lib:is_lambda(Arg) of
     true ->
       case proplists:lookup(Arg, FLs) of
@@ -786,8 +789,10 @@ pp_argument(Arg, FLs) ->
           Arity = cuter_lib:lambda_arity(Arg),
           ClauseList = pp_lambda_kvs(KVs, FLs) ++ [pp_lambda_default(Default, Arity)],
           lists:flatten(["fun", string:join(ClauseList, "; "), " end"]);
+        {_, L} when IsP ->
+          [L];
         {_, L} ->
-          [L]
+          [L, $0]
       end;
     false when is_list(Arg) ->
       case io_lib:printable_list(Arg) of
@@ -807,7 +812,7 @@ pp_lambda_kvs(KVs, FLs) ->
   [pp_lambda_kv(KV, FLs) || KV <- KVs].
 
 pp_lambda_kv({Args, Val}, FLs) ->
-  SArgs = [pp_argument(A, FLs) || A <- Args],
+  SArgs = [pp_argument(A, FLs, true) || A <- Args],
   Ls = lists:flatten([find_inner_vars(A, FLs) || A <- Args]),
   G = case length(Ls) of
     0 ->

--- a/src/cuter_pp.erl
+++ b/src/cuter_pp.erl
@@ -742,7 +742,7 @@ pp_input_fully_verbose(Input, _MFA) ->
 
 pp_assignments(FLs) ->
   PP_Fn = fun(Fn) -> pp_argument(Fn, proplists:delete(Fn, FLs)) end,
-  Ss = [io_lib:format("~s = ~s,", [[L, $0], PP_Fn(Fn)]) || {Fn, L} <- FLs],
+  Ss = [io_lib:format("~s = ~s, ", [[L, $0], PP_Fn(Fn)]) || {Fn, L} <- FLs],
   string:join(Ss, "").
 
 pp_arguments(Args) ->
@@ -765,7 +765,7 @@ preprocess_fn(A, InFn) ->
     false ->
       [];
     true when InFn ->
-      [A] ++ preprocess_fn(A, false);
+      [A | preprocess_fn(A, false)];
     true ->
       KVs = cuter_lib:lambda_kvs(A),
       AllKs = lists:flatten([Ks || {Ks, _} <- KVs]),

--- a/src/cuter_pp.erl
+++ b/src/cuter_pp.erl
@@ -814,12 +814,12 @@ pp_lambda_kv({Args, Val}, FLs) ->
   SArgs = [pp_argument(A, FLs, true) || A <- Args],
   Ls = lists:flatten([find_inner_vars(A, FLs) || A <- Args]),
   G = case length(Ls) of
-    0 ->
-      "";
-    _ ->
-    GLs = [io_lib:format("~s =:= ~s", [[L], [L,  $0]]) || L <- Ls],
-    io_lib:format(" when ~s", [string:join(GLs, ", ")])
-  end,
+        0 ->
+          "";
+        _ ->
+          GLs = [io_lib:format("~s =:= ~s", [[L], [L,  $0]]) || L <- Ls],
+	  io_lib:format(" when ~s", [string:join(GLs, ", ")])
+      end,
   StrArgs = ["(", string:join(SArgs, ","), ")"],
   lists:flatten([StrArgs, G, " -> ", pp_argument(Val, [])]).
 

--- a/test/ftest/src/funs.erl
+++ b/test/ftest/src/funs.erl
@@ -1,7 +1,7 @@
 -module(funs).
 -export([f1/1, f2/3, f3/3, f41/3, f42/3, f5/4, f6/1, f7/2, f8/2,
          f91/3, f92/2, f10/1, f11/3, f12/1, f1ws/1, f2ws/3, f3ws/3,
-         f5ws/4, f1hs/1, f13a/2, f13b/2, f14/2, mf/3, ff_f_g/3]).
+         f5ws/4, f1hs/1, f13a/2, f13b/2, f14/2, mf/3, ff_f_g/3, ff_f_g_h/4]).
 
 -spec f1(fun((integer()) -> integer())) -> ok.
 f1(F) ->
@@ -253,6 +253,23 @@ ff_f_g(FF, F, G) ->
   case FF_F =:= 123 andalso FF_G =:= 456 of
      true ->
        error(ff_f_g_bug);
+     false ->
+       ok
+  end.
+
+%-spec ff_f_g_h(fun((fun((integer()) -> integer())) -> integer()),
+%               fun((integer()) -> integer()),
+%               fun((integer()) -> integer()),
+%               fun((integer()) -> integer())) -> 'ok'.
+
+-spec ff_f_g_h(fun((fun_i2i()) -> integer()), fun_i2i(), fun_i2i(), fun_i2i()) -> 'ok'.
+ff_f_g_h(FF, F, G, H) ->
+  FF_F = FF(F),
+  FF_G = FF(G),
+  FF_H = FF(H),
+  case FF_F =:= 123 andalso FF_G =:= 456 andalso FF_H =:= 789 of
+     true ->
+       error(ff_f_g_h_bug);
      false ->
        ok
   end.

--- a/test/ftest/src/funs.erl
+++ b/test/ftest/src/funs.erl
@@ -241,9 +241,9 @@ mf(F, P, L) ->
      false -> error(mf_prop_fails)
    end.
 
-%-spec ff_f_g(fun((fun((integer()) -> integer())) -> integer()),
-%             fun((integer()) -> integer()),
-%             fun((integer()) -> integer())) -> 'ok'.
+%%-spec ff_f_g(fun((fun((integer()) -> integer())) -> integer()),
+%%             fun((integer()) -> integer()),
+%%             fun((integer()) -> integer())) -> 'ok'.
 
 -type fun_i2i() :: fun((integer()) -> integer()).
 -spec ff_f_g(fun((fun_i2i()) -> integer()), fun_i2i(), fun_i2i()) -> 'ok'.
@@ -257,10 +257,10 @@ ff_f_g(FF, F, G) ->
        ok
   end.
 
-%-spec ff_f_g_h(fun((fun((integer()) -> integer())) -> integer()),
-%               fun((integer()) -> integer()),
-%               fun((integer()) -> integer()),
-%               fun((integer()) -> integer())) -> 'ok'.
+%%-spec ff_f_g_h(fun((fun((integer()) -> integer())) -> integer()),
+%%               fun((integer()) -> integer()),
+%%               fun((integer()) -> integer()),
+%%               fun((integer()) -> integer())) -> 'ok'.
 
 -spec ff_f_g_h(fun((fun_i2i()) -> integer()), fun_i2i(), fun_i2i(), fun_i2i()) -> 'ok'.
 ff_f_g_h(FF, F, G, H) ->

--- a/test/ftest/src/funs.erl
+++ b/test/ftest/src/funs.erl
@@ -1,7 +1,7 @@
 -module(funs).
 -export([f1/1, f2/3, f3/3, f41/3, f42/3, f5/4, f6/1, f7/2, f8/2,
          f91/3, f92/2, f10/1, f11/3, f12/1, f1ws/1, f2ws/3, f3ws/3,
-         f5ws/4, f1hs/1, f13a/2, f13b/2, f14/2, mf/3]).
+         f5ws/4, f1hs/1, f13a/2, f13b/2, f14/2, mf/3, ff_f_g/3]).
 
 -spec f1(fun((integer()) -> integer())) -> ok.
 f1(F) ->
@@ -240,3 +240,19 @@ mf(F, P, L) ->
      true -> ok;
      false -> error(mf_prop_fails)
    end.
+
+%-spec ff_f_g(fun((fun((integer()) -> integer())) -> integer()),
+%             fun((integer()) -> integer()),
+%             fun((integer()) -> integer())) -> 'ok'.
+
+-type fun_i2i() :: fun((integer()) -> integer()).
+-spec ff_f_g(fun((fun_i2i()) -> integer()), fun_i2i(), fun_i2i()) -> 'ok'.
+ff_f_g(FF, F, G) ->
+  FF_F = FF(F),
+  FF_G = FF(G),
+  case FF_F =:= 123 andalso FF_G =:= 456 of
+     true ->
+       error(ff_f_g_bug);
+     false ->
+       ok
+  end.

--- a/test/ftests.json
+++ b/test/ftests.json
@@ -1208,6 +1208,19 @@
                 "$1(($2,)) == 123 and $1(($3,)) == 456"
             ],
             "skip": false
+        },
+        {
+            "module": "funs",
+            "function": "ff_f_g_h",
+            "args": "[fun (F) when is_function(F, 1) -> 42 end, fun (_) -> 1 end, fun (_) -> 2 end, fun (_) -> 3 end]",
+            "depth": "42",
+            "errors": true,
+            "arity": 4,
+            "nondeterministic": true,
+            "solutions": [
+                "$1(($2,)) == 123 and $1(($3,)) == 456 and $1(($4,)) == 789"
+            ],
+            "skip": false
         }
     ]
 }

--- a/test/ftests.json
+++ b/test/ftests.json
@@ -1,18 +1,6 @@
 {
     "tests": [
         {
-            "module": "funs",
-            "function": "ff_f_g",
-            "args": "[fun (F) when is_function(F, 1) -> 42 end, fun (_) -> 1 end, fun (_) -> 2 end]",
-            "depth": "42",
-            "errors": false,
-            "arity": 3,
-            "nondeterministic": false,
-            "solutions": [
-            ],
-            "skip": false
-        },
-        {
             "module": "bitstr",
             "function": "f11",
             "args": "[0]",
@@ -1205,6 +1193,19 @@
             "solutions": [
                 "type($2((0,))) == type(True)",
                 "[$1((x,)) for x in $3 if $2((x,))] != [z for z in [$1((y,)) for y in $3] if $2((z,))]"
+            ],
+            "skip": false
+        },
+        {
+            "module": "funs",
+            "function": "ff_f_g",
+            "args": "[fun (F) when is_function(F, 1) -> 42 end, fun (_) -> 1 end, fun (_) -> 2 end]",
+            "depth": "42",
+            "errors": true,
+            "arity": 3,
+            "nondeterministic": true,
+            "solutions": [
+                "$1(($2,)) == 123 and $1(($3,)) == 456"
             ],
             "skip": false
         }

--- a/test/ftests.json
+++ b/test/ftests.json
@@ -1,6 +1,18 @@
 {
     "tests": [
         {
+            "module": "funs",
+            "function": "ff_f_g",
+            "args": "[fun (F) when is_function(F, 1) -> 42 end, fun (_) -> 1 end, fun (_) -> 2 end]",
+            "depth": "42",
+            "errors": false,
+            "arity": 3,
+            "nondeterministic": false,
+            "solutions": [
+            ],
+            "skip": false
+        },
+        {
             "module": "bitstr",
             "function": "f11",
             "args": "[0]",

--- a/test/functional_test
+++ b/test/functional_test
@@ -54,13 +54,22 @@ def run(testDir, n):
                 printOutputAndExit(output)
         # Validate the errors found.
         solutions = interesting.strip().split("\n")
-        found = filter_funs(["[" + re.search(r"\((.*)\)", sol).group(1) + "]" for sol in solutions])
+        found = filter_funs(get_matches(solutions))
         diffMode = False if "nondeterministic" in test and test["nondeterministic"] else True
         if not validate(test["arity"], diffMode, found, test["solutions"]):
             printOutputAndExit(output)
 
+def get_matches(solutions):
+    pat = r"(\s*(?P<vars>\w+\s*=\s*.+)\s*,\s*)?\w+:\w+\((?P<mfa>.*)\)"
+    matches = []
+    for solution in solutions:
+        m = re.search(pat, solution)
+        vs = m.group("vars").lstrip("31m") if m.group("vars") else ""
+        matches.append((vs, "[" + m.group("mfa") + "]"))
+    return matches
+
 def filter_funs(found):
-    filtered = [f for f in found if not "#Fun" in f]
+    filtered = [f for f in found if not "#Fun" in f[1]]
     if len(found) > len(filtered):
         print "[INFO] Initial function argument filtered from errors."
     return filtered
@@ -103,12 +112,12 @@ def validate(arity, diffMode, found, expected):
     Parameters:
         arity : integer
         diffMode : bool
-        args : list of string
-        cond : list of string
+        found : list of string * string tuples
+        expected : list of string
     """
     allfound = set([])
-    for i in found:
-        matched = set([r for r in expected if is_expected_input(arity, diffMode, i, str(r))])
+    for f in found:
+        matched = set([r for r in expected if is_expected_input(arity, diffMode, f, str(r))])
         if len(matched) == 0:
             return False
         allfound = allfound | matched
@@ -120,16 +129,21 @@ def is_expected_input(arity, diffMode, args, cond):
     Parameters:
         arity : integer
         diffMode : bool
-        args : string
+        args : string * string
         cond : string
     """
+    vs, mfa = args
     if diffMode:
-        return args == cond
+        return mfa == cond
     else:
         pms = ",".join(["x{}".format(i + 1) for i in range(arity)])
         cond = cond.replace("$", "x")
         try:
-            assign = "[{}]=terms.parse('{}')".format(pms, args)
+            d = {}
+            if vs:
+                vassign = "d=terms.parse('{}')".format(vs)
+                exec(vassign)
+            assign = "[{}]=terms.parse_with_vars('{}', d)".format(pms, mfa)
             exec(assign)
             return eval(cond)
         except:

--- a/test/terms.py
+++ b/test/terms.py
@@ -6,11 +6,15 @@ import re, parsimonious
 
 def parse(s):
     ast = to_ast(s)
-    return eval_ast(ast)[0]
+    return eval_ast(ast, {})[0]
+
+def parse_with_vars(s, vs):
+    ast = to_ast(s)
+    return eval_ast(ast, vs)[0]
 
 def to_ast(s):
     grammar = parsimonious.Grammar("""\
-    term = boolean / function / atom / list / tuple / number / bitstring / string
+    term = assignments / boolean / function / atom / list / tuple / number / bitstring / string / var
     _ = ~"\s*"
     list = ("[" _ term (_ "," _ term)* _ "]") / ("[" _ "]")
     tuple = ("{" _ term (_ "," _ term)* _ "}") / ("{" _ "}")
@@ -23,14 +27,17 @@ def to_ast(s):
     string = '"' ~r'(\\\\"|[^"])*' '"'
     bitstr = '"' ~r'(\\\\"|[^"])*' '"'
     function = "fun" point (_ ";" _ point)* _ "end"
-    point = ("(" _ (term (_ "," _ term)*)? _ ")" _ "->" _ term) / ("(" _ any (_ "," _ any)* ")" _ "->" _ term)
+    point = ("(" _ (term (_ "," _ term)*)? _ ")" _ when? _ "->" _ term) / ("(" _ any (_ "," _ any)* ")" _ "->" _ term)
+    when = "when" _ var _ "=:=" _ var ("," _ var _ "=:=" _ var)*
+    assignments = _ var _ "=" _ function (_ "," _ var _ "=" _ function)*
+    var = ~"[0-9A-Z]+"
     any = "_"
     """)
     return grammar.parse(s)
 
-def eval_ast(ast):
+def eval_ast(ast, vs):
     node = ast.expr_name
-    ts = [y for x in map(eval_ast, ast.children) for y in x]
+    ts = [y for x in [eval_ast(z, vs) for z in ast.children] for y in x]
     if node == "number":
         return [float(ast.text) if "." in ast.text else int(ast.text)]
     elif node == "boolean":
@@ -58,17 +65,39 @@ def eval_ast(ast):
     elif node == "function":
         return [lambda x: call_fn(ts, x)]
     elif node == "point":
-        return [(tuple(ts[:-1]), ts[-1])]
+        ps = ts[:-2] if len(ts) >= 2 and is_when(ts[-2]) else ts[:-1]
+        w = ts[-2][1] if len(ts) >= 2 and is_when(ts[-2]) else {}
+        for i, p in enumerate(ps):
+            if p in w:
+                ps[i] = w[p]
+        return [(tuple(ps), ts[-1])]
     elif node == "any":
         return ["_"]
+    elif node == "var":
+        if ast.text in vs:
+            return [vs[ast.text]]
+        return [ast.text]
+    elif node == "when":
+        return [("__when", dict(list(group(ts))))]
+    elif node == "assignments":
+        return [dict(list(group(ts)))]
     else:
         return ts
+
+def group(l):
+    for i in range(0, len(l), 2):
+        val = l[i:i+2]
+        if len(val) == 2:
+          yield tuple(val)
+
+def is_when(x):
+    return isinstance(x, tuple) and len(x) == 2 and x[0] == "__when"
 
 def eval_string(ast):
     return ast.text[1:-1].replace(r'\"', '"')
 
 def get_otherwise(points):
-    for (pms, v) in points:
+    for pms, v in points:
         if all(p == "_" or p == () for p in pms):
             return (pms, v)
     return (None, None)


### PR DESCRIPTION
e.g.
```
aggelgian@...:~/cuter$ ./cuter -r -v -p 2 -s 8 f2 mainfun '[fun(F) when is_function(F, 1) -> 42 end]'
Compiling f2.erl ... ok
Testing f2:mainfun/1 ...
f2:mainfun/1
    Spec:
        fun((fun((fun((integer()) -> integer())) -> integer())) -> ok)
    Types:


WARNING: Encountered an unsupported type while parsing the types in Core Erlang forms!
  Form: {type,608,map,any}

f2:mainfun(#Fun<erl_eval.6.128620087>) ... ok
xxxxxxxxxx
f2:mainfun(fun(_) -> 321 end) ... ok
xxxxxxxxx
A = fun(_) -> 7 end, f2:mainfun(fun(A) -> 654; (_) -> 321 end) ... ok
x

Solver Statistics ...
  - Solved models   : 2
  - Unsolved models : 20

No Runtime Errors Occured
```