### PR TITLE
Store SMT invocations for debugging.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ venv
 
 dev/*
 temp/
+
+# Logs
+
+smt.log.*

--- a/cuter
+++ b/cuter
@@ -30,6 +30,7 @@ def main():
   parser.add_argument("--no-type-normalization", action='store_true', help="disable the normalization specifications & types")
   parser.add_argument("--z3-timeout", metavar="N", type=int, default=2,
     help="set the timeout N for the Z3 SMT solver (default: %(default)s)")
+  parser.add_argument("-ds", "--debug_smt", action='store_true', help="store debug information for SMT solving")
 
   # Parse the arguments
   args = parser.parse_args()
@@ -91,6 +92,8 @@ def main():
     opts.append("no_type_normalization")
   if args.w != None:
       opts.append("{{whitelist, '{}'}}".format(args.w))
+  if args.debug_smt:
+    opts.append("debug_smt")
   strOpts = ",".join(opts)
 
   # Run CutEr

--- a/priv/cuter_global.py
+++ b/priv/cuter_global.py
@@ -7,7 +7,7 @@ LISTS_FORALL_PATS = 1
 LISTS_FORALL_NO_PATS = 2
 LISTS_EXPAND = 3
 
-def init():
+def init(debug=False):
     global __TTY__
     global __RUN__
     global __LISTS_INTERP__
@@ -16,6 +16,7 @@ def init():
     global __LOG_JSON_LOADED__
     global __LOG_MODEL_UNKNOWN__
     global __LOG_DEBUG_INFO__
+    global __LOG_SMT__
 
     __TTY__ = "tty" in sys.argv
     __RUN__ = True
@@ -27,4 +28,5 @@ def init():
     __LOG_DATA_RECEIVED__ = False
     __LOG_JSON_LOADED__ = False
     __LOG_MODEL_UNKNOWN__ = False
+    __LOG_SMT__ = debug
 

--- a/priv/cuter_interface.py
+++ b/priv/cuter_interface.py
@@ -12,6 +12,7 @@ import cuter_common as cc
 ## Parse the arguments.
 
 parser = argparse.ArgumentParser(description="Run the Solver Component.")
+parser.add_argument("-d", "--debug", action='store_true', help="record debug information")
 parser.add_argument("-s", "--smt", action='store_true', help="use the SMTv2 backend")
 parser.add_argument("-t", "--timeout", metavar="N", type=int, default=2,
     help="set the timeout N for the SMT solver (default: %(default)s)")
@@ -19,7 +20,7 @@ args = parser.parse_args()
 
 ## Main Program
 
-cglb.init()
+cglb.init(debug=args.debug)
 # Initialize the communication with Erlang
 erlport = cp.ErlangPort()
 # Initialize the Solver interface

--- a/priv/cuter_logger.py
+++ b/priv/cuter_logger.py
@@ -1,13 +1,52 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import os, json, datetime
+import datetime
+import json
+import os
+
 import cuter_global as cglb
 
 DATA_RECEIVED_LOG = "data_received.log"
 JSON_LOADED_LOG = "json_loaded.log"
 MODEL_UNKNOWN = "model_unknown.log"
 DEBUG_LOG = "debug.log"
+
+def touch(fname):
+  if os.path.exists(fname):
+    os.utime(fname, None)
+  else:
+    open(fname, 'a').close()
+
+class Logger(object):
+  def __init__(self, fname = None):
+    if fname:
+      if os.path.isfile(fname):
+        self.fd = open(fname, "a")
+      else:
+        self.fd = open(fname, "w")
+    else:
+      self.fd = None
+
+  def log(self, msg):
+    if self.fd:
+      self.fd.write(msg + "\n")
+
+
+class SMTLogger(Logger):
+  def __init__(self):
+    if not cglb.__LOG_SMT__:
+      super(SMTLogger, self).__init__()
+    else:
+      n = 1
+      while os.path.exists("smt.log.{:05d}".format(n)):
+        n += 1
+      fname = "smt.log.{:05d}".format(n)
+      touch(fname)
+      super(SMTLogger, self).__init__(fname)
+
+  def logComment(self, msg):
+    self.log("; " + msg)
 
 
 def debug_info(data):

--- a/priv/cuter_smt_process.py
+++ b/priv/cuter_smt_process.py
@@ -1,86 +1,72 @@
 # -*- coding: utf-8 -*-
 
 import subprocess
+
+import cuter_logger
 from cuter_smt_library import serialize, unserialize
-
-
-debug = False
-
-
-if debug:
-	import os.path
-	filename = "solver.txt"
-	if os.path.isfile(filename):
-		clog = open(filename, "a")
-	else:
-		clog = open(filename, "w")
-
-
-def log(msg = ""):
-	if debug:
-		clog.write(msg + "\n")
 
 
 class Solver:
 
-	def __init__(self, arguments):
-		"""
-		Create a subprocess using provided program arguments.
-		"""
-		self.process = subprocess.Popen(
-			arguments,
-			stdin=subprocess.PIPE,
-			stdout=subprocess.PIPE,
-			stderr=subprocess.PIPE,
-			universal_newlines=True
-		)
-		log("; " + " ".join(arguments))
+  def __init__(self, arguments):
+    """
+    Create a subprocess using provided program arguments.
+    """
+    self.process = subprocess.Popen(
+      arguments,
+      stdin=subprocess.PIPE,
+      stdout=subprocess.PIPE,
+      stderr=subprocess.PIPE,
+      universal_newlines=True
+    )
+    self.logger = cuter_logger.SMTLogger()
+    self.logger.logComment(" ".join(arguments))
 
-	def kill(self):
-		self.process.kill()
+  def kill(self):
+    self.process.kill()
 
-	def write(self, stmt):
-		line = serialize(stmt)
-		self.process.stdin.write(line + "\n")
-		log(line)
+  def write(self, stmt):
+    line = serialize(stmt)
+    self.process.stdin.write(line + "\n")
+    self.logger.log(line)
 
-	def read(self):
-		open_cnt = 0
-		close_cnt = 0
-		lines = []
-		while True:
-			line = self.process.stdout.readline()[:-1]
-			lines.append(line)
-			open_cnt += line.count("(")
-			close_cnt += line.count(")")
-			if open_cnt == close_cnt:
-				break;
-		smt = "\n".join(lines)
-		log(smt)
-		if open_cnt == 0 and close_cnt == 0:
-			return smt
-		return unserialize(smt)
+  def read(self):
+    open_cnt = 0
+    close_cnt = 0
+    lines = []
+    while True:
+      line = self.process.stdout.readline()[:-1]
+      lines.append(line)
+      open_cnt += line.count("(")
+      close_cnt += line.count(")")
+      if open_cnt == close_cnt:
+        break;
+    smt = "\n".join(lines)
+    self.logger.logComment(smt)
+    if open_cnt == 0 and close_cnt == 0:
+      return smt
+    return unserialize(smt)
 
-	def check_sat(self):
-		self.write(["check-sat"])
-		return self.read()
+  def check_sat(self):
+    self.write(["check-sat"])
+    return self.read()
 
-	def get_value(self, *expr):
-		self.write(["get-value", list(expr)])
-		return self.read()
+  def get_value(self, *expr):
+    self.write(["get-value", list(expr)])
+    return self.read()
 
-	def exit(self):
-		self.write(["exit"])
+  def exit(self):
+    self.write(["exit"])
 
 
 #class SolverCVC4(Solver):
 #
-#	def __init__(self):
-#		Solver.__init__(self, ["cvc4", "--lang=smt2", "--tlimit={}".format(timeout * 1000), "--fmf-fun", "--incremental"])
-#		self.write(["set-logic", "UFDTLIRA"])
+# def __init__(self):
+#   Solver.__init__(self, ["cvc4", "--lang=smt2", "--tlimit={}".format(timeout * 1000), "--fmf-fun", "--incremental"])
+#   self.write(["set-logic", "UFDTLIRA"])
 
 
 class SolverZ3(Solver):
 
-	def __init__(self, timeout):
-		Solver.__init__(self, ["z3", "-smt2", "-T:{}".format(timeout), "-in"])
+  def __init__(self, timeout):
+    Solver.__init__(self, ["z3", "-smt2", "-T:{}".format(timeout), "-in"])

--- a/src/cuter.erl
+++ b/src/cuter.erl
@@ -46,6 +46,7 @@
 -define(SUPPRESS_UNSUPPORTED_MFAS, suppress_unsupported).
 -define(NO_TYPE_NORMALIZATION, no_type_normalization).
 -define(Z3_TIMEOUT, z3_timeout).
+-define(DEBUG_SMT, debug_smt).
 
 -type default_option() :: {?POLLERS_NO, ?ONE}
                         .
@@ -63,6 +64,7 @@
                 | ?SUPPRESS_UNSUPPORTED_MFAS
                 | ?NO_TYPE_NORMALIZATION
                 | {?Z3_TIMEOUT, pos_integer()}
+                | ?DEBUG_SMT
                 .
 
 %% ----------------------------------------------------------------------------
@@ -294,10 +296,19 @@ z3_timeout([]) -> ?TWO;
 z3_timeout([{?Z3_TIMEOUT, N}|_Rest]) -> N;
 z3_timeout([_|Rest]) -> z3_timeout(Rest).
 
+-spec debug_smt([option()]) -> boolean().
+debug_smt(Options) -> lists:member(?DEBUG_SMT, Options).
+
 -spec get_solver_backend([option()]) -> nonempty_string().
 get_solver_backend(Options) ->
   T = z3_timeout(Options),
-  ?PYTHON_CALL ++ " --smt --timeout " ++ integer_to_list(T).
+  Base = ?PYTHON_CALL ++ " --smt --timeout " ++ integer_to_list(T),
+  case debug_smt(Options) of
+    false ->
+      Base;
+    true ->
+      Base ++ " -d"
+  end.
 
 -spec get_whitelist([option()]) -> cuter_mock:whitelist().
 get_whitelist([]) ->


### PR DESCRIPTION
Enable to store the SMT model that is sent for validation to the solver.
- Each invocation creates a separate log file, named smt.log.XXXXX,
  in the current working directory.
- Guard this feature behind a flag ("-ds", "--debug_smt").