### PR TITLE
Do not attempt to fix variables to specific values

### DIFF
--- a/priv/cuter_port.py
+++ b/priv/cuter_port.py
@@ -47,7 +47,6 @@ def decode_command(erlport, erlSolver, data):
         scmd.SolverCommand.SOLVE: decode_solve,
         scmd.SolverCommand.GET_MODEL: decode_get_model,
         scmd.SolverCommand.ADD_AXIOMS: decode_add_axioms,
-        scmd.SolverCommand.FIX_VARIABLE: decode_fix_variable,
         scmd.SolverCommand.RESET_SOLVER: decode_reset_solver,
         scmd.SolverCommand.STOP: decode_stop,
     }
@@ -83,13 +82,6 @@ def decode_add_axioms(erlport, erlSolver, cmd):
     Adds the axioms.
     """
     erlSolver.add_axioms()
-
-def decode_fix_variable(erlport, erlSolver, cmd):
-    """
-    Fixes a variable to a specific value.
-    """
-    var, val = cmd.symbvar, cmd.symbvar_value
-    erlSolver.fix_parameter(var, val)
 
 def decode_reset_solver(erlport, erlSolver, cmd):
     """

--- a/src/cuter_proto_solver_command.proto
+++ b/src/cuter_proto_solver_command.proto
@@ -12,7 +12,7 @@ message SolverCommand {
         SOLVE = 1;
         GET_MODEL = 2;
         ADD_AXIOMS = 3;
-        FIX_VARIABLE = 4;
+        FIX_VARIABLE = 4; // Deprecated.
         RESET_SOLVER = 5;
         STOP = 6;
     }

--- a/src/cuter_serial.erl
+++ b/src/cuter_serial.erl
@@ -40,7 +40,6 @@ to_term(Msg) ->
 solver_command(Command) -> solver_command(Command, none).
 
 -spec solver_command(load_trace_file, {file:name(), integer()}) -> binary()
-                  ; (fix_variable, {cuter_symbolic:symbolic(), any()}) -> binary()
                   ; (commands_no_opts(), none) -> binary().
 solver_command(Command, Options) ->
   Msg = to_solver_command(Command, Options),
@@ -349,10 +348,6 @@ to_solver_command(get_model, none) ->
   #'SolverCommand'{type='GET_MODEL'};
 to_solver_command(add_axioms, none) ->
   #'SolverCommand'{type='ADD_AXIOMS'};
-to_solver_command(fix_variable, {SymbVar, Value}) ->
-  #'SolverCommand'{type='FIX_VARIABLE',
-                   symbvar=to_erlang_term(SymbVar),
-                   symbvar_value=to_erlang_term(Value)};
 to_solver_command(reset_solver, none) ->
   #'SolverCommand'{type='RESET_SOLVER'};
 to_solver_command(stop, none) ->


### PR DESCRIPTION
If the entry point has arity > 1, and the solve returns unknown or
timeout for a model, we would try to fix some of the variables to
specific values to simplify the model.

This functionality is not helpful in our case. If the solver reponds
with unknown or times out, then there is a regression in the solver or
in our tool.