### PR TITLE
Make configuration globally accessible

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -80,7 +80,8 @@ SRC_MODULES = \
 	cerl_pmatch \
 	cuter_strategy \
 	cuter_bfs_strategy \
-	cuter_metrics
+	cuter_metrics \
+	cuter_config
 
 UTEST_MODULES = \
 	cuter_tests_lib \
@@ -97,7 +98,8 @@ UTEST_MODULES = \
 	cuter_pp_tests \
 	types_and_specs \
 	types_and_specs2 \
-	cuter_metrics_tests
+	cuter_metrics_tests \
+	cuter_config_tests
 
 FTEST_MODULES = \
 	bitstr \

--- a/cuter
+++ b/cuter
@@ -30,11 +30,14 @@ def main():
   parser.add_argument("--disable-pmatch", action='store_true', help="disable the pattern matching compilation")
   parser.add_argument("--sorted-errors", action='store_true', help="report the erroneous inputs in a sorted order")
   parser.add_argument("--suppress-unsupported", action='store_true', help="suppresses the reporting of unsupported MFAs")
-  parser.add_argument("--no-type-normalization", action='store_true', help="disable the normalization specifications & types")
+  parser.add_argument("--disable-type-normalization", action='store_true',
+    help="disable the normalization specifications & types")
   parser.add_argument("--z3-timeout", metavar="N", type=int, default=2,
     help="set the timeout N for the Z3 SMT solver (default: %(default)s)")
-  parser.add_argument("-ds", "--debug_smt", action='store_true', help="store debug information for SMT solving")
+  parser.add_argument("-ds", "--debug-smt", action='store_true', help="store debug information for SMT solving")
   parser.add_argument("-m", "--metrics", action='store_true', help="report collected metrics")
+  parser.add_argument("--debug-keep-traces", action='store_true', help="keep execution traces for debugging")
+  parser.add_argument("--debug-solver-fsm", action='store_true', help="output debug logs for the solver FSM")
 
   # Parse the arguments
   args = parser.parse_args()
@@ -83,25 +86,29 @@ def main():
   opts.append("{{z3_timeout, {}}}".format(args.z3_timeout))
   opts.append("{{strategy, {}}}".format(args.strategy))
   if args.verbose:
-    opts.append("verbose_execution_info")
+    opts.append("verbose_execution")
   if args.coverage:
     opts.append("coverage")
   if args.fully_verbose:
-    opts.append("fully_verbose_execution_info")
+    opts.append("fully_verbose_execution")
   if args.disable_pmatch:
     opts.append("disable_pmatch")
   if args.sorted_errors:
     opts.append("sorted_errors")
   if args.suppress_unsupported:
     opts.append("suppress_unsupported")
-  if args.no_type_normalization:
-    opts.append("no_type_normalization")
+  if args.disable_type_normalization:
+    opts.append("disable_type_normalization")
   if args.w != None:
       opts.append("{{whitelist, '{}'}}".format(args.w))
   if args.debug_smt:
     opts.append("debug_smt")
   if args.metrics:
     opts.append("report_metrics")
+  if args.debug_keep_traces:
+    opts.append("debug_keep_traces")
+  if args.debug_solver_fsm:
+    opts.append("debug_solver_fsm")
   strOpts = ",".join(opts)
 
   # Run CutEr

--- a/include/cuter_macros.hrl
+++ b/include/cuter_macros.hrl
@@ -45,17 +45,75 @@
 -define(EXECUTION_COUNTER_PREFIX, '__exec_counter').
 
 %%====================================================================
+%% Configuration parameters.
+%%====================================================================
+
+%% If enabled, we keep execution traces for debugging.
+-define(DEBUG_KEEP_TRACES, debug_keep_traces).
+%% If enabled, we keep the logs of the solver models and the outcomes.
+-define(DEBUG_SMT, debug_smt).
+%% If enabled, outputs debug logs for the solver FSM.
+-define(DEBUG_SOLVER_FSM, debug_solver_fsm).
+
+-type debug_options() :: ?DEBUG_KEEP_TRACES 
+                       | ?DEBUG_SMT
+                       | ?DEBUG_SOLVER_FSM
+                       .
+
+%% Sets the working directory for CutEr.
+-define(WORKING_DIR, working_dir).
+%% Sets the timeout for the Z3 SMT solver in seconds.
+-define(Z3_TIMEOUT, z3_timeout).
+%% If enabled, reports the collected metrics.
+-define(REPORT_METRICS, report_metrics).
+%% Selects the search strategy for the scheduler.
+-define(STRATEGY, strategy).
+%% If enabled, we compute and report the achieved code coverage.
+-define(CALCULATE_COVERAGE, coverage).
+%% If enabled, we disable the pattern matching compilation optimization.
+-define(DISABLE_PMATCH, disable_pmatch).
+%% If enabled, we suppresses the reporting of unsupported MFAs.
+-define(SUPPRESS_UNSUPPORTED_MFAS, suppress_unsupported).
+%% If enabled, we disable the normalization of types and specs.
+-define(DISABLE_TYPE_NORMALIZATION, disable_type_normalization).
+%% If enabled, we report the erroneous inputs in a sorted order.
+-define(SORTED_ERRORS, sorted_errors).
+%% Set the verbosity level for reporting.
+-define(VERBOSE_EXECUTION, verbose_execution).
+-define(FULLY_VERBOSE_EXECUTION, fully_verbose_execution).
+-define(VERBOSITY_LEVEL, verbosity_level).
+%% If set, loads the whitelisted MFAs from the file with the given path.
+-define(WHITELISTED_MFA_PATH, whitelist).
+-define(WHITELISTED_MFAS, whitelisted_mfas).
+%% Sets the number of concurrent solver processes.
+-define(NUM_SOLVERS, number_of_solvers).
+%% Sets the number of concurrent concolic execution processes.
+-define(NUM_POLLERS, number_of_pollers).
+
+-type runtime_options() :: {?Z3_TIMEOUT, pos_integer()} 
+                         | ?REPORT_METRICS
+                         | {?STRATEGY, atom()}
+                         | ?CALCULATE_COVERAGE
+                         | ?DISABLE_PMATCH
+                         | ?SUPPRESS_UNSUPPORTED_MFAS
+                         | ?DISABLE_TYPE_NORMALIZATION
+                         | ?SORTED_ERRORS
+                         | ?VERBOSE_EXECUTION
+                         | ?FULLY_VERBOSE_EXECUTION
+                         | {?WHITELISTED_MFA_PATH, file:filename()}
+                         | {?NUM_SOLVERS, pos_integer()}
+                         | {?NUM_POLLERS, pos_integer()}
+                         | {?WORKING_DIR, file:filename()}
+                         .
+
+%%====================================================================
 %% Flags & Default Values
 %%====================================================================
 
 -define(LOGGING_FLAG, ok).
--define(DELETE_TRACE, ok).
 -define(LOG_UNSUPPORTED_MFAS, ok).
-%%-define(VERBOSE_SCHEDULER, ok).
 %%-define(VERBOSE_FILE_DELETION, ok).
-%%-define(VERBOSE_SOLVING, ok).
 %%-define(VERBOSE_MERGING, ok).
-%%-define(VERBOSE_REPORTING, ok).
 -define(USE_SPECS, ok).
 
 %%====================================================================

--- a/src/cuter_analyzer.erl
+++ b/src/cuter_analyzer.erl
@@ -3,7 +3,7 @@
 -module(cuter_analyzer).
 
 -export([get_result/1, get_mapping/1, get_traces/1, is_runtime_error/1, solving_stats/2,
-         get_int_process/1, process_raw_execution_info/1, calculate_coverage/3,
+         get_int_process/1, process_raw_execution_info/1, calculate_coverage/2,
          report_metrics/0,
          %% Constructor & accessors for #raw{}
          mk_raw_info/5, traces_of_raw_info/1, int_of_raw_info/1,
@@ -85,7 +85,12 @@ process_raw_execution_info(Info) ->
   DataDir = Info#raw.dir,
   MergedTraceFile = cuter_lib:get_merged_tracefile(DataDir),
   cuter_merger:merge_traces(Info, MergedTraceFile),
-  cuter_lib:clear_and_delete_dir(Info#raw.dir, MergedTraceFile),
+  case cuter_config:fetch(?DEBUG_KEEP_TRACES) of
+    {ok, true} ->
+      ok;
+    _ ->
+      cuter_lib:clear_and_delete_dir(Info#raw.dir, MergedTraceFile)
+  end,
   PathVertex = cuter_log:path_vertex(MergedTraceFile),
   Rvs = cuter_log:locate_reversible(MergedTraceFile),
   RvsCnt = length(Rvs),
@@ -161,37 +166,37 @@ solving_stats(Solved, NotSolved) ->
 %% Calculate coverage.
 %% ----------------------------------------------------------------------------
 
--spec calculate_coverage(boolean(), pid(), cuter_cerl:visited_tags()) -> ok.
-calculate_coverage(false, _, _) -> ok;
-calculate_coverage(true, CodeServer, VisitedTags) ->
+-spec calculate_coverage(pid(), cuter_cerl:visited_tags()) -> ok.
+calculate_coverage(CodeServer, VisitedTags) ->
   cuter_pp:coverage_title(),
   %% Calculate the branch coverage.
   FeasibleTags = cuter_codeserver:get_feasible_tags(CodeServer, cuter_cerl:node_types_branches()),
-  {Visited1, All1, Coverage1} = calculate_coverage(FeasibleTags, VisitedTags),
+  {Visited1, All1, Coverage1} = calculate_coverage_h(FeasibleTags, VisitedTags),
   cuter_pp:branch_coverage(Visited1, All1, Coverage1),
   %% Calculate the branch coverage (without compiler generated clauses).
   FeasibleTagsNoComp = cuter_codeserver:get_feasible_tags(CodeServer, cuter_cerl:node_types_branches_nocomp()),
-  {Visited2, All2, Coverage2} = calculate_coverage(FeasibleTagsNoComp, VisitedTags),
+  {Visited2, All2, Coverage2} = calculate_coverage_h(FeasibleTagsNoComp, VisitedTags),
   cuter_pp:branch_coverage_nocomp(Visited2, All2, Coverage2),
   %% Calculate the conditions coverage.
   FeasibleTagsCond = cuter_codeserver:get_feasible_tags(CodeServer, cuter_cerl:node_types_conditions()),
-  {Visited3, All3, Coverage3} = calculate_coverage(FeasibleTagsCond, VisitedTags),
+  {Visited3, All3, Coverage3} = calculate_coverage_h(FeasibleTagsCond, VisitedTags),
   cuter_pp:condition_coverage(Visited3, All3, Coverage3),
   %% Calculate the conditions coverage (without compiler generated clauses).
   FeasibleTagsCondNoComp = cuter_codeserver:get_feasible_tags(CodeServer, cuter_cerl:node_types_conditions_nocomp()),
-  {Visited4, All4, Coverage4} = calculate_coverage(FeasibleTagsCondNoComp, VisitedTags),
+  {Visited4, All4, Coverage4} = calculate_coverage_h(FeasibleTagsCondNoComp, VisitedTags),
   cuter_pp:condition_coverage_nocomp(Visited4, All4, Coverage4),
   %% Calculate the paths coverage.
   FeasibleTagsPaths = cuter_codeserver:get_feasible_tags(CodeServer, cuter_cerl:node_types_paths()),
-  {Visited5, All5, Coverage5} = calculate_coverage(FeasibleTagsPaths, VisitedTags),
+  {Visited5, All5, Coverage5} = calculate_coverage_h(FeasibleTagsPaths, VisitedTags),
   cuter_pp:condition_outcome_coverage(Visited5, All5, Coverage5),
   %% Calculate the condition coverage (without compiler generated clauses).
   FeasibleTagsPathsNoComp = cuter_codeserver:get_feasible_tags(CodeServer, cuter_cerl:node_types_paths_nocomp()),
-  {Visited6, All6, Coverage6} = calculate_coverage(FeasibleTagsPathsNoComp, VisitedTags),
+  {Visited6, All6, Coverage6} = calculate_coverage_h(FeasibleTagsPathsNoComp, VisitedTags),
   cuter_pp:condition_outcome_coverage_nocomp(Visited6, All6, Coverage6).
 
--spec calculate_coverage(cuter_cerl:visited_tags(), cuter_cerl:visited_tags()) -> {non_neg_integer(), non_neg_integer(), float()}.
-calculate_coverage(Feasible, Visited) ->
+-spec calculate_coverage_h(cuter_cerl:visited_tags(), 
+                           cuter_cerl:visited_tags()) -> {non_neg_integer(), non_neg_integer(), float()}.
+calculate_coverage_h(Feasible, Visited) ->
   case gb_sets:size(Feasible) of
     0 ->
       {0, 0, 100.0};

--- a/src/cuter_config.erl
+++ b/src/cuter_config.erl
@@ -1,0 +1,95 @@
+%% -*- erlang-indent-level: 2 -*-
+%%------------------------------------------------------------------------------
+-module(cuter_config).
+-behaviour(gen_server).
+
+%% External API.
+-export([fetch/1, store/2, start/0, stop/0]).
+%% gen_server callbacks
+-export([init/1, terminate/2, code_change/3, handle_info/2, handle_call/3, handle_cast/2]).
+
+-define(CONFIG_SERVER, config_server).
+
+-type from() :: {pid(), reference()}.
+-type name() :: atom().
+-type value() :: any().
+-type fetch_ret() :: {ok, value()} | not_found.
+
+%% The persistent state of the server.
+-record(st, {
+  %% The storage for the configuration parameters.
+  parameters = orddict:new() :: orddict:orddict(name(), value())
+}).
+-type state() :: #st{}.
+
+%% ============================================================================
+%% External API
+%% ============================================================================
+
+%% Starts the configuration server.
+-spec start() -> ok.
+start() ->
+  case gen_server:start_link({local, ?CONFIG_SERVER}, ?MODULE, [], []) of
+    {ok, _Pid} -> ok;
+    {error, R} -> exit({config_start, R})
+  end.
+
+%% Stops the configuration server.
+-spec stop() -> ok.
+stop() ->
+  gen_server:call(?CONFIG_SERVER, stop).
+
+%% Stores the value for the given parameter.
+-spec store(name(), value()) -> ok.
+store(Parameter, Value) ->
+  gen_server:cast(?CONFIG_SERVER, {store, Parameter, Value}).
+
+%% Retrieves the value for the given parameter.
+-spec fetch(name()) -> fetch_ret().
+fetch(Parameter) ->
+  gen_server:call(?CONFIG_SERVER, {fetch, Parameter}).
+
+%% ============================================================================
+%% gen_server callbacks (Server Implementation)
+%% ============================================================================
+
+%% gen_server callback : init/1
+-spec init([]) -> {ok, state()}.
+init([]) ->
+  {ok, #st{}}.
+
+%% gen_server callback : terminate/2
+-spec terminate(term(), state()) -> ok.
+terminate(_Reason, _State) ->
+  ok.
+
+%% gen_server callback : code_change/3
+-spec code_change(any(), state(), any()) -> {ok, state()}.
+code_change(_OldVsn, State, _Extra) ->
+  {ok, State}.  %% No change planned.
+
+%% gen_server callback : handle_call/3
+-spec handle_call({fetch, name()}, from(), state()) -> {reply, fetch_ret(), state()}
+               ; (stop, from(), state()) -> {stop, normal, ok, state()}
+               .
+%% Retrieves the value for the given parameter.
+handle_call({fetch, Name}, _From, #st{parameters = Ps}=S) ->
+  case orddict:find(Name, Ps) of
+    error ->
+      {reply, not_found, S};
+    {ok, V} ->
+      {reply, {ok, V}, S}
+  end;
+%% Stops the configuration server.
+handle_call(stop, _From, State) ->
+  {stop, normal, ok, State}.
+
+%% gen_server callback : handle_cast/2
+-spec handle_cast({store, name(), value()}, state()) -> {noreply, state()}.
+handle_cast({store, K, V}, #st{parameters = Ps}=S) ->
+  {noreply, S#st{parameters = orddict:store(K, V, Ps)}}.
+
+%% gen_server callback : handle_info/2
+-spec handle_info(any(), state()) -> {noreply, state()}.
+handle_info(_What, State) ->
+  {noreply, State}.

--- a/src/cuter_lib.erl
+++ b/src/cuter_lib.erl
@@ -87,7 +87,7 @@ logfile_name(Dir, Pid) ->
   F = erlang:pid_to_list(Pid) -- "<>",
   filename:absname("proc-" ++ F, Dir).
 
-%% Delete the whole subfolder/file structure of a specific directory
+%% Delete the whole subfolder/file structure of a specific directory.
 -spec clear_and_delete_dir(file:filename_all()) -> ok.
 clear_and_delete_dir(D) ->
   clear_and_delete_dir(D, none).
@@ -100,7 +100,7 @@ clear_and_delete_dir(D, EF) ->
   cuter_pp:delete_file(D, true),
   case filelib:is_regular(D) of
     true ->
-      _ = delete_file(D),
+      _ = file:delete(D),
       ok;
     false ->
       case file:del_dir(D) of
@@ -113,12 +113,6 @@ clear_and_delete_dir(D, EF) ->
         _ -> ok
       end
   end.
-
--ifdef(DELETE_TRACE).
-delete_file(F) -> file:delete(F).
--else.
-delete_file(_) -> ok.
--endif.
 
 %% List the absolute names of the files/folders in a directory in ascending order
 -spec list_dir(file:filename_all()) -> [file:filename()].

--- a/src/cuter_pp.erl
+++ b/src/cuter_pp.erl
@@ -5,11 +5,11 @@
 
 %% gen_server callbacks
 -export([init/1, terminate/2, code_change/3, handle_info/2, handle_call/3, handle_cast/2]).
--export([start/1, stop/0]).
+-export([start/0, stop/0]).
 %% Report information about the concolic executions.
 -export([mfa/1, input/2, error_retrieving_spec/2, execution_status/2,
          execution_info/2, path_vertex/2, flush/1, errors_found/1,
-         form_has_unsupported_type/1, invalid_ast_with_pmatch/2, code_logs/3]).
+         form_has_unsupported_type/1, invalid_ast_with_pmatch/2, code_logs/1]).
 %% Report information about solving.
 -export([solving_failed_unsat/0, solving_failed_timeout/0, solving_failed_unknown/0]).
 %% Report callgraph related info.
@@ -99,9 +99,7 @@
                        | condition_coverage | condition_coverage_nocomp
                        | condition_outcome_coverage | condition_outcome_coverage_nocomp.
 
--type call() :: {whitelist_loaded, file:name(), cuter_mock:whitelist()}
-              | {whitelist_error, file:name(), any()}
-              | {module_non_existing, atom()}
+-type call() :: {module_non_existing, atom()}
               | {mfa_non_existing, mfa()}
               | {mfa, mfa()}
               | {invalid_ast_with_pmatch, module(), any()}
@@ -158,13 +156,13 @@ fully_verbose_exec_info(PpLevel) ->
   PpLevel#pp_level{execInfo = ?FULLY_VERBOSE}.
 
 %% ============================================================================
-%% Eternal API
+%% External API
 %% ============================================================================
 
 %% Starts the server.
--spec start(pp_level()) -> ok.
-start(PpLevel) ->
-  case gen_server:start({local, ?PRETTY_PRINTER}, ?MODULE, [self(), PpLevel], []) of
+-spec start() -> ok.
+start() ->
+  case gen_server:start({local, ?PRETTY_PRINTER}, ?MODULE, [self()], []) of
     {ok, _Pid} -> ok;
     {error, Reason} -> exit({failed_to_start_ppserver, Reason})
   end.
@@ -240,9 +238,9 @@ errors_found(Errors) ->
   gen_server:call(?PRETTY_PRINTER, {errors_found, Errors}).
 
 %% Prints the logs of a CodeServer.
--spec code_logs(cuter_codeserver:logs(), cuter_mock:whitelist(), boolean()) -> ok.
-code_logs(Logs, Whitelist, SuppressUnsupported) ->
-  gen_server:call(?PRETTY_PRINTER, {code_logs, Logs, Whitelist, SuppressUnsupported}).
+-spec code_logs(cuter_codeserver:logs()) -> ok.
+code_logs(Logs) ->
+  gen_server:call(?PRETTY_PRINTER, {code_logs, Logs}).
 
 %% Print the parsed spec of the MFA.
 -spec parsed_spec(cuter_types:erl_spec()) -> ok.
@@ -250,16 +248,32 @@ parsed_spec(Spec) ->
   gen_server:call(?PRETTY_PRINTER, {parsed_spec, Spec}).
 
 %% ----------------------------------------------------------------------------
-%% Parsing of options.
+%% Whitelisted MFAs.
 %% ----------------------------------------------------------------------------
 
 -spec loaded_whitelist(file:name(), cuter_mock:whitelist()) -> ok.
 loaded_whitelist(File, Whitelist) ->
-  gen_server:call(?PRETTY_PRINTER, {whitelist_loaded, File, Whitelist}).
+  {ok, VerbosityLevel} = cuter_config:fetch(?VERBOSITY_LEVEL),
+  case VerbosityLevel#pp_level.execInfo of
+    ?MINIMAL ->
+      io:format(standard_error, "Loaded whitelisted MFAs from ~p.~n", [File]);
+    ?VERBOSE ->
+      io:format("Loaded whitelisted MFAs from ~p.~n", [File]);
+    ?FULLY_VERBOSE ->
+      MFAs = cuter_mock:get_whitelisted_mfas(Whitelist),
+      io:format("Loaded the following whitelisted MFAs from ~p.~n  ~p~n", [File, MFAs])
+  end.
 
 -spec error_loading_whitelist(file:name(), any()) -> ok.
 error_loading_whitelist(File, Error) ->
-  gen_server:call(?PRETTY_PRINTER, {whitelist_error, File, Error}).
+  {ok, VerbosityLevel} = cuter_config:fetch(?VERBOSITY_LEVEL),
+  case VerbosityLevel#pp_level.execInfo of
+    ?MINIMAL ->
+      io:format(standard_error, "Error ~p occured when loading whitelisted MFAs from ~p.~n", 
+                [Error, File]);
+    _ ->
+      io:format("Error ~p occured when loading whitelisted MFAs from ~p.~n", [Error, File])
+  end.
 
 %% ----------------------------------------------------------------------------
 %% Failed pre-run checks.
@@ -338,10 +352,11 @@ loading_visited_module(M) ->
 %% ============================================================================
 
 %% gen_server callback : init/1
--spec init([pid() | pp_level(), ...]) -> {ok, state()}.
-init([Super, PpLevel]) ->
+-spec init([pid(), ...]) -> {ok, state()}.
+init([Super]) ->
   %% process_flag(trap_exit, true),
   link(Super),
+  {ok, PpLevel} = cuter_config:fetch(?VERBOSITY_LEVEL),
   {ok, #st{ info = dict:new()
           , nl = false
           , pplevel = PpLevel
@@ -439,24 +454,6 @@ handle_call({solved_models, Solved, NotSolved}, _From, State=#st{pplevel = PpLev
       io:format("~nSolver Statistics ...~n"),
       io:format("  - Solved models   : ~w~n", [Solved]),
       io:format("  - Unsolved models : ~w~n", [NotSolved])
-  end,
-  {reply, ok, State};
-
-%% Parsing of options.
-
-handle_call({whitelist_loaded, File, Whitelist}, _From, State=#st{pplevel = PpLevel}) ->
-  case PpLevel#pp_level.execInfo of
-    ?MINIMAL -> io:format(standard_error, "Loaded whitelisted MFAs from ~p.~n", [File]);
-    ?VERBOSE -> io:format("Loaded whitelisted MFAs from ~p.~n", [File]);
-    ?FULLY_VERBOSE ->
-      MFAs = cuter_mock:get_whitelisted_mfas(Whitelist),
-      io:format("Loaded the following whitelisted MFAs from ~p.~n  ~p~n", [File, MFAs])
-  end,
-  {reply, ok, State};
-handle_call({whitelist_error, File, Error}, _From, State=#st{pplevel = PpLevel}) ->
-  case PpLevel#pp_level.execInfo of
-    ?MINIMAL -> io:format(standard_error, "Error ~p occured when loading whitelisted MFAs from ~p.~n", [Error, File]);
-    _ -> io:format("Error ~p occured when loading whitelisted MFAs from ~p.~n", [Error, File])
   end,
   {reply, ok, State};
 
@@ -572,8 +569,9 @@ handle_call({errors_found, Errors}, _From, State=#st{pplevel = PpLevel}) ->
   pp_erroneous_inputs(Errors, PpLevel#pp_level.execInfo),
   {reply, ok, State#st{nl = false}};
 %% Prints the logs of a CodeServer.
-handle_call({code_logs, CodeLogs, Whitelist, SuppressUnsupported}, _From, State=#st{pplevel = PpLevel}) ->
-  pp_code_logs(CodeLogs, Whitelist, SuppressUnsupported, PpLevel#pp_level.execInfo),
+handle_call({code_logs, CodeLogs}, _From, State=#st{pplevel = PpLevel}) ->
+  {ok, Whitelist} = cuter_config:fetch(?WHITELISTED_MFAS),
+  pp_code_logs(CodeLogs, Whitelist, PpLevel#pp_level.execInfo),
   {reply, ok, State#st{nl = false}};
 %% Prints the parsed spec of the mfa.
 handle_call({parsed_spec, Spec}, _From, State=#st{mfa = Mfa, pplevel = PpLevel}) ->
@@ -888,19 +886,20 @@ pp_node_logs(Logs) ->
 %% Report the CodeServer's logs
 %% ----------------------------------------------------------------------------
 
--spec pp_code_logs(cuter_codeserver:logs(), cuter_mock:whitelist(), boolean(), level()) -> ok.
-pp_code_logs(Logs, Whitelist, SuppressUnsupported, ?MINIMAL) ->
-  pp_unsupported_mfas(Logs, Whitelist, SuppressUnsupported);
-pp_code_logs(Logs, Whitelist, SuppressUnsupported, ?VERBOSE) ->
-  pp_unsupported_mfas(Logs, Whitelist, SuppressUnsupported);
-pp_code_logs(Logs, Whitelist, _SuppressUnsupported, ?FULLY_VERBOSE) ->
+-spec pp_code_logs(cuter_codeserver:logs(), cuter_mock:whitelist(), level()) -> ok.
+pp_code_logs(Logs, Whitelist, L) when L =:= ?MINIMAL orelse L =:= ?VERBOSE ->
+  case cuter_config:fetch(?SUPPRESS_UNSUPPORTED_MFAS) of
+    {ok, true} ->
+      ok;
+    _ ->
+      pp_unsupported_mfas(Logs, Whitelist)
+  end;
+pp_code_logs(Logs, Whitelist, ?FULLY_VERBOSE) ->
   pp_code_logs_fully_verbose(Logs, Whitelist).
 
 %% Reports the unsupported mfas.
--spec pp_unsupported_mfas(cuter_codeserver:logs(), cuter_mock:whitelist(), boolean()) -> ok.
-pp_unsupported_mfas(_Logs, _Whitelist, true) ->
-  ok;
-pp_unsupported_mfas(Logs, Whitelist, false) ->
+-spec pp_unsupported_mfas(cuter_codeserver:logs(), cuter_mock:whitelist()) -> ok.
+pp_unsupported_mfas(Logs, Whitelist) ->
   UnsupportedMfas = cuter_codeserver:unsupportedMfas_of_logs(Logs),
   case filter_non_reportable(UnsupportedMfas, Whitelist) of
     [] -> ok;
@@ -1055,90 +1054,82 @@ delete_file(F, false) ->
 delete_file(_F, _Intact) -> ok.
 -endif.
 
-%%
-%% Verbose solving
-%%
-
-%%-spec sat() -> ok.
-%%-ifdef(VERBOSE_SOLVING).
-%%sat() ->
-%%  io:format("[SLV] (solving) SAT~n").
-%%-else.
-%%sat() -> ok.
-%%-endif.
-
-%%-spec not_sat() -> ok.
-%%-ifdef(VERBOSE_SOLVING).
-%%not_sat() ->
-%%  io:format("[SLV] (solving) NOT SAT~n").
-%%-else.
-%%not_sat() -> ok.
-%%-endif.
+%% ----------------------------------------------------------------------------
+%% Solver FSM
+%% ----------------------------------------------------------------------------
 
 -spec model_start() -> ok.
--ifdef(VERBOSE_SOLVING).
 model_start() ->
-  io:format("[SLV] (generating_model) Beginning of the model~n").
--else.
-model_start() -> ok.
--endif.
+  case cuter_config:fetch(?DEBUG_SOLVER_FSM) of
+    {ok, true} ->
+      io:format("[SLV] (generating_model) Beginning of the model~n");
+    _ ->
+      ok
+  end.
 
 -spec model_end() -> ok.
--ifdef(VERBOSE_SOLVING).
 model_end() ->
-  io:format("[SLV] (expecting_var) End of the model~n").
--else.
-model_end() -> ok.
--endif.
+  case cuter_config:fetch(?DEBUG_SOLVER_FSM) of
+    {ok, true} ->
+      io:format("[SLV] (expecting_var) End of the model~n");
+    _ ->
+      ok
+  end.
 
 -spec received_var(cuter_symbolic:symbolic()) -> ok.
--ifdef(VERBOSE_SOLVING).
 received_var(Var) ->
-  io:format("[SLV] (expecting_var) Var: ~p~n", [Var]).
--else.
-received_var(_Var) -> ok.
--endif.
+  case cuter_config:fetch(?DEBUG_SOLVER_FSM) of
+    {ok, true} ->
+      io:format("[SLV] (expecting_var) Var: ~p~n", [Var]);
+    _ ->
+      ok
+  end.
 
 -spec received_val(any()) -> ok.
--ifdef(VERBOSE_SOLVING).
 received_val(Val) ->
-  io:format("[SLV] (expecting_value) Val: ~p~n", [Val]).
--else.
-received_val(_Val) -> ok.
--endif.
+  case cuter_config:fetch(?DEBUG_SOLVER_FSM) of
+    {ok, true} ->
+      io:format("[SLV] (expecting_value) Val: ~p~n", [Val]);
+    _ ->
+      ok
+  end.
 
 -spec port_closed() -> ok.
--ifdef(VERBOSE_SOLVING).
 port_closed() ->
-  io:format("[SLV] (finished) Port Closed~n").
--else.
-port_closed() -> ok.
--endif.
+  case cuter_config:fetch(?DEBUG_SOLVER_FSM) of
+    {ok, true} ->
+      io:format("[SLV] (finished) Port Closed~n");
+    _ ->
+      ok
+  end.
 
 -spec undecoded_msg(binary(), cuter_solver:state()) -> ok.
--ifdef(VERBOSE_SOLVING).
 undecoded_msg(Msg, State) ->
-  io:format("[SLV INFO] (~p) ~p~n", [State, Msg]).
--else.
-undecoded_msg(_Msg, _State) -> ok.
--endif.
+  case cuter_config:fetch(?DEBUG_SOLVER_FSM) of
+    {ok, true} ->
+      io:format("[SLV INFO] (~p) ~p~n", [State, Msg]);
+    _ ->
+      ok
+  end.
 
 -spec fsm_started(port()) -> ok.
--ifdef(VERBOSE_SOLVING).
 fsm_started(Port) ->
-  io:format("[FSM] (idle) Started (Port ~p)~n", [Port]).
--else.
-fsm_started(_Port) -> ok.
--endif.
+  case cuter_config:fetch(?DEBUG_SOLVER_FSM) of
+    {ok, true} ->
+      io:format("[FSM] (idle) Started (Port ~p)~n", [Port]);
+    _ ->
+      ok
+  end.
 
 -type cmd() :: {file:name(), integer()} | cuter_symbolic:mapping() | binary().	% FIXME
 -spec send_cmd(cuter_solver:state(), cmd(), string()) -> ok.
--ifdef(VERBOSE_SOLVING).
-send_cmd(State, Cmd, Descr) ->
-  io:format("[FSM] (~p) ~p~n  ~p~n", [State, Descr, Cmd]).
--else.
-send_cmd(_State, _Cmd, _Descr) -> ok.
--endif.
+send_cmd(State, _, Descr) ->
+  case cuter_config:fetch(?DEBUG_SOLVER_FSM) of
+    {ok, true} ->
+      io:format("[FSM] (~p) ~p~n", [State, Descr]);
+    _ ->
+      ok
+  end.
 
 -spec debug_unexpected_solver_message(any()) -> ok.
 debug_unexpected_solver_message(Info) ->

--- a/src/cuter_types.erl
+++ b/src/cuter_types.erl
@@ -2,7 +2,7 @@
 %%------------------------------------------------------------------------------
 -module(cuter_types).
 
--export([parse_spec/4, retrieve_types/1, retrieve_specs/1, find_spec/2,
+-export([parse_spec/3, retrieve_types/1, retrieve_specs/1, find_spec/2,
 	 get_kind/1, find_remote_deps_of_type/2, find_remote_deps_of_spec/2]).
 
 -export([params_of_t_function_det/1, ret_of_t_function/1, atom_of_t_atom_lit/1,
@@ -910,16 +910,16 @@ insert_userdef_and_update_seen(Seen, IsTopLevel, NormalizedType, Deps) ->
 %% Traverse a spec and substitute the local and remote types.
 %% ----------------------------------------------------------------------------
 
--spec parse_spec(mfa(), stored_spec_value(), many_stored_types(), boolean()) -> erl_spec().
-parse_spec(Mfa, Spec, ManyStoredTypes, NormalizeTypes) ->
+-spec parse_spec(mfa(), stored_spec_value(), many_stored_types()) -> erl_spec().
+parse_spec(Mfa, Spec, ManyStoredTypes) ->
   Conf = mk_conf(Mfa, ManyStoredTypes),
   {ParsedSpec, Deps} = parse_spec_clauses(Spec, Conf, []),
   true = cleanup_conf(Conf),
   %% TODO Maybe also normalize the parsed spec.
-  case NormalizeTypes of
-    false ->
+  case cuter_config:fetch(?DISABLE_TYPE_NORMALIZATION) of
+    {ok, true} ->
       {ParsedSpec, Deps};
-    true ->
+    _ ->
       NormalizedDeps = normalize_type_deps(Deps),
       {ParsedSpec, NormalizedDeps}
   end.

--- a/test/ftests.json
+++ b/test/ftests.json
@@ -1133,7 +1133,7 @@
             "depth": "10",
             "errors": true,
             "arity": 1,
-            "xopts": "--no-type-normalization",
+            "xopts": "--disable-type-normalization",
             "solutions": [
                 "[{42,{17,nil}}]"
             ],

--- a/test/utest/src/cuter_config_tests.erl
+++ b/test/utest/src/cuter_config_tests.erl
@@ -1,0 +1,23 @@
+%% -*- erlang-indent-level: 2 -*-
+%%------------------------------------------------------------------------------
+-module(cuter_config_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-spec test() -> 'ok' | {'error', term()}.  %% This should be provided by EUnit
+
+-spec parameter_test() -> ok.
+parameter_test() ->
+  Name = some_parameter,
+  ok = cuter_config:start(),
+  ok = cuter_config:store(Name, 42),
+  R = cuter_config:fetch(Name),
+  ok = cuter_config:stop(),
+  ?assertEqual({ok, 42}, R).
+
+-spec fetch_unknown_parameter_test() -> ok.
+fetch_unknown_parameter_test() ->
+  ok = cuter_config:start(),
+  R = cuter_config:fetch(some_metric),
+  ok = cuter_config:stop(),
+  ?assertEqual(not_found, R).

--- a/test/utest/src/cuter_iserver_tests.erl
+++ b/test/utest/src/cuter_iserver_tests.erl
@@ -4,10 +4,9 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include("include/eunit_config.hrl").
+-include_lib("include/cuter_macros.hrl").
 
 -spec test() -> 'ok' | {'error', term()}.  %% This should be provided by EUnit
-
--define(Pmatch, true).
 
 -type descr() :: nonempty_string().
 
@@ -25,8 +24,13 @@ start_stop_test_() ->
 setup() ->
   process_flag(trap_exit, true),
   Dir = cuter_tests_lib:setup_dir(),
-  ok = cuter_pp:start(cuter_pp:default_reporting_level()),
-  CodeServer = cuter_codeserver:start(self(), ?Pmatch, cuter_mock:empty_whitelist(), true),
+  cuter_config:start(),
+  cuter_config:store(?DISABLE_PMATCH, false),
+  cuter_config:store(?DISABLE_TYPE_NORMALIZATION, false),
+  cuter_config:store(?VERBOSITY_LEVEL, cuter_pp:default_reporting_level()),
+  cuter_config:store(?WHITELISTED_MFAS, cuter_mock:empty_whitelist()),
+  ok = cuter_pp:start(),
+  CodeServer = cuter_codeserver:start(self()),
   Server = cuter_iserver:start(lists, reverse, [[42,17]], Dir, ?TRACE_DEPTH, CodeServer),
   {Dir, Server}.
 
@@ -37,6 +41,7 @@ cleanup({Dir, Server}) ->
     5000 -> ok
   end,
   cuter_pp:stop(),
+  cuter_config:stop(),
   timer:sleep(200),
   cuter_lib:clear_and_delete_dir(Dir).
 

--- a/test/utest/src/cuter_solver_tests.erl
+++ b/test/utest/src/cuter_solver_tests.erl
@@ -4,6 +4,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include("include/eunit_config.hrl").
+-include_lib("include/cuter_macros.hrl").
 
 -spec test() -> 'ok' | {'error', term()}.  %% This should be provided by EUnit
 
@@ -84,6 +85,8 @@ solve_simple_test_() ->
 -spec setup() -> {file:name(), file:name(), string()}.
 setup() ->
   put('__conc_depth', 100),
+  cuter_config:start(),
+  cuter_config:store(?DEBUG_SOLVER_FSM, false),
   ok = cuter_metrics:start(),
   Dir = cuter_tests_lib:setup_dir(),
   Fname = filename:absname("logfile", Dir),
@@ -92,6 +95,7 @@ setup() ->
 
 cleanup({Dir, _Fname, _Python}) ->
   ok = cuter_metrics:stop(),
+  cuter_config:stop(),
   cuter_lib:clear_and_delete_dir(Dir).
 
 -spec create_logfile(file:name(), [any()], fun((file:io_device(), [cuter_symbolic:symbolic()]) -> ok)) -> [cuter_symbolic:mapping()].


### PR DESCRIPTION
Move configuration to a globally accessible process.
Passing parameters around does not scale. Also, macros do not allow the user to override them at runtime.

Also, consider the runtime options as proplists.