### PR TITLE
Add a test that shows a regression

### DIFF
--- a/test/ftest/src/sum.erl
+++ b/test/ftest/src/sum.erl
@@ -1,5 +1,5 @@
 -module(sum).
--export([classify/1]).
+-export([classify/1, classify2/1]).
 
 -include_lib("proper/include/proper.hrl").
 
@@ -10,6 +10,14 @@ prop_classify_ok() ->
 -spec classify([number()]) -> 'negative' | 'small' | 'big'.
 classify(L) ->
   case lists:sum(L) of
+    S when S < 0 -> negative;
+    S when S < 4711 -> small;
+    S when S > 4711 -> big
+  end.
+
+-spec classify2([number()]) -> 'negative' | 'small' | 'big'.
+classify2(L) ->
+  case lists:foldl(fun erlang:'+'/2, 0, L) of
     S when S < 0 -> negative;
     S when S < 4711 -> small;
     S when S > 4711 -> big

--- a/test/ftests.json
+++ b/test/ftests.json
@@ -671,6 +671,20 @@
             "skip": false
         },
         {
+            "module": "sum",
+            "function": "classify2",
+            "args": "[[]]",
+            "depth": "25",
+            "withProper": true,
+            "errors": true,
+            "arity": 1,
+            "nondeterministic": true,
+            "solutions": [
+                "sum($1) == 4711"
+            ],
+            "skip": false
+        },
+        {
             "module": "funs",
             "function": "f14",
             "args": "[fun(_) -> 1 end, []]",


### PR DESCRIPTION
The added test is a small variation of a test that we already had in the
same test file.  I am sure it used to work OK in a previous version of
CutEr because I have been using it in demos.  Most likely, some recent
code refactoring broke it - perhaps we can use `git bisect` to find it.

What's weird is not so much that CutEr does not find the input that
crashes the unit under test, but that the inputs that we report are not
crashing inputs.