### PR TITLE
Abstract the code & metadata of an MFA as a kfun().

### DIFF
--- a/src/cuter_cerl.erl
+++ b/src/cuter_cerl.erl
@@ -32,7 +32,7 @@
 -export_type([kfun/0]).
 
 %% kfun() is an ADT that holds the code and metadata for an MFA.
--type kfun() :: #{
+-opaque kfun() :: #{
   %% The code of the MFA.
   code := code(),
   %% Whether the MFA is exported or not.

--- a/src/cuter_codeserver.erl
+++ b/src/cuter_codeserver.erl
@@ -311,8 +311,9 @@ get_feasible_tags_of_mfa({M,F,A}=Mfa, NodeTypes, State=#st{whitelist = Whitelist
           gb_sets:new();
         {true, Cache} ->
 %          io:format("Looking Up ~p~n", [Mfa]),
-          {ok, {Def, _}} = lookup_in_module_cache(Mfa, Cache),
-          cuter_cerl:collect_feasible_tags(Def, NodeTypes)
+          {ok, Kfun} = lookup_in_module_cache(Mfa, Cache),
+          Code = cuter_cerl:kfun_code(Kfun),
+          cuter_cerl:collect_feasible_tags(Code, NodeTypes)
       end
   end.
 

--- a/test/utest/src/cuter_cerl_tests.erl
+++ b/test/utest/src/cuter_cerl_tests.erl
@@ -62,8 +62,9 @@ generate_and_collect_tags({M, Cache}) ->
   _ = cuter_cerl:load(M, Cache, TagGen, false),
   FoldFn = fun(Elem, Acc) ->
       case Elem of
-        {{_,_,_}, {Def, _}} ->
-          Tags = cuter_cerl:collect_feasible_tags(Def, all),
+        {{_,_,_}, Kfun} ->
+          Code = cuter_cerl:kfun_code(Kfun),
+          Tags = cuter_cerl:collect_feasible_tags(Code, all),
           gb_sets:union(Acc, Tags);
         _ -> Acc
       end
@@ -95,3 +96,14 @@ setup(M) ->
 cleanup({_M, MDb}) ->
   ets:delete(MDb).
 
+%% -------------------------------------------------------------------
+%% kfun API
+%% -------------------------------------------------------------------
+
+-spec construct_and_access_kfun_test() -> ok.
+construct_and_access_kfun_test() ->
+  Code = cerl:c_fun([cerl:c_nil()], cerl:c_nil()),
+  Kfun = cuter_cerl:kfun(Code, true),
+  GotCode = cuter_cerl:kfun_code(Kfun),
+  GotIsExported = cuter_cerl:kfun_is_exported(Kfun),
+  [?assertEqual(Code, GotCode), ?assertEqual(true, GotIsExported)].


### PR DESCRIPTION
The intention is to make consumers of code unaware of how it is stored
in CutEr.

Each MFA will be an opaque kfun() and each module will be an opaque
kmodule(), the module cache will be a collection of kmodules() etc, and we will provide an API to access and modify them.