### PR TITLE
Abstract the code of a module as a kmodule().

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -12,6 +12,7 @@ EBIN = ebin
 PRIV = $(PWD)/priv
 TEST = test
 UTEST_SRC = $(TEST)/utest/src
+UTEST_INCLUDE = $()/utest/include
 UTEST_EBIN = $(TEST)/utest/ebin
 FTEST_SRC = $(TEST)/ftest/src
 FTEST_EBIN = $(TEST)/ftest/ebin
@@ -183,7 +184,7 @@ $(EBIN)/%.beam: %.erl
 
 $(UTEST_EBIN)/%.beam: %.erl
 	@echo "ERLC $<"
-	@$(ERLC) $(ERLC_INCLUDE) $(ERLC_FLAGS) $(ERLC_MACROS) -o $(UTEST_EBIN) $<
+	@$(ERLC) $(ERLC_INCLUDE) -I $(UTEST_INCLUDE) $(ERLC_FLAGS) $(ERLC_MACROS) -o $(UTEST_EBIN) $<
 
 $(FTEST_EBIN)/no_debug_info.beam: no_debug_info.erl
 	@echo "ERLC $<"

--- a/src/cuter_cerl.erl
+++ b/src/cuter_cerl.erl
@@ -3,10 +3,10 @@
 -module(cuter_cerl).
 
 %% External exports
--export([retrieve_spec/2, get_tags/1, id_of_tag/1, tag_from_id/1, empty_tag/0,
-         get_stored_types/1, empty_tagId/0, collect_feasible_tags/2]).
+-export([get_tags/1, id_of_tag/1, tag_from_id/1, empty_tag/0,
+         empty_tagId/0, collect_feasible_tags/2]).
 %% Core AST extraction.
--export([load/4, get_core/2]).
+-export([load/3, get_core/2]).
 %% Node types generators.
 -export([node_types_branches/0, node_types_branches_nocomp/0, node_types_all/0,
          node_types_conditions/0, node_types_conditions_nocomp/0,
@@ -15,6 +15,9 @@
 -export([classify_attributes/1]).
 %% kfun API.
 -export([kfun/2, kfun_code/1, kfun_is_exported/1]).
+%% kmodule API.
+-export([destroy_kmodule/1, kmodule/4, kmodule_kfun/2, kmodule_mfa_spec/2, 
+  kmodule_specs/1, kmodule_types/1]).
 
 %% We are using the records representation of Core Erlang Abstract Syntax Trees
 -include_lib("compiler/src/core_parse.hrl").
@@ -29,7 +32,18 @@
 	      tagID/0, tag/0, tag_generator/0, visited_tags/0,
 	      type_info/0, spec_info/0]).
 
--export_type([kfun/0]).
+-export_type([kfun/0, kmodule/0]).
+
+-type ast() :: cerl:c_module().
+
+%% TODO(aggelgian): Change it to a map.
+%% In each kmodule(), the following information is stored:
+%%   Key               Value
+%% --------  ---------------------------
+%% types      cuter_types:stored_types()
+%% specs      cuter_types:stored_specs()
+%% mfa()      kfun()
+-opaque kmodule() :: ets:tid().
 
 %% kfun() is an ADT that holds the code and metadata for an MFA.
 -opaque kfun() :: #{
@@ -40,7 +54,6 @@
 }.
 -type code() :: cerl:c_fun().
 
--type info()          :: 'anno' | 'attributes' | 'exports' | 'name'.
 -type compile_error() :: {'error', string()}.
 -type load_error()    :: {'error', 'preloaded'} | compile_error().
 
@@ -141,28 +154,65 @@
                             | cerl_func() | cerl_bounded_func().
 
 
-%%====================================================================
-%% External exports
-%%====================================================================
--spec load(M, cuter_codeserver:module_cache(), tag_generator(), boolean()) -> {ok, M} | load_error() when M :: cuter:mod().
-load(Mod, Cache, TagGen, WithPmatch) ->
-  case get_core(Mod, WithPmatch) of
+%% ===================================================================
+%% External API
+%% ===================================================================
+
+%% Loads the AST of the given module and stores it as a kmodule().
+-spec load(module(), tag_generator(), boolean()) -> {ok, kmodule()} | load_error().
+load(M, TagGen, WithPmatch) ->
+  case get_core(M, WithPmatch) of
     {ok, #c_module{}=AST} -> % just a sanity check that we get back a module
-      store_module(Mod, AST, Cache, TagGen),
-      {ok, Mod};
+      Exports = extract_exports(M, AST),
+      {TypeAttrs, SpecAttrs} = classify_attributes(cerl:module_attrs(AST)),
+      Types = cuter_types:retrieve_types(TypeAttrs),
+      Specs = cuter_types:retrieve_specs(SpecAttrs),
+      Defs = cerl:module_defs(AST),
+      Funs = [process_fundef(D, Exports, M, TagGen) || D <- Defs],
+      {ok, kmodule(M, Types, Specs, Funs)};
     {error, _} = Error -> Error
   end.
 
-%% Retrieves the spec of a function from a stored module's info.
--spec retrieve_spec(cuter_codeserver:module_cache(), fa()) -> {ok, cuter_types:stored_spec_value()} | error.
-retrieve_spec(Cache, FA) ->
-  {ok, Specs} = cuter_codeserver:lookup_in_module_cache(specs, Cache),
-  cuter_types:find_spec(FA, Specs).
+%% -------------------------------------------------------------------
+%% kmodule API
+%% -------------------------------------------------------------------
 
--spec get_stored_types(cuter_codeserver:module_cache()) -> cuter_types:stored_types().
-get_stored_types(Cache) ->
-  {ok, Types} = cuter_codeserver:lookup_in_module_cache(types, Cache),
+-spec kmodule(module(), cuter_types:stored_types(), cuter_types:stored_specs(), [{mfa(), kfun()}]) -> kmodule().
+kmodule(M, Types, Specs, Funs) ->
+  Kmodule = ets:new(M, [ordered_set, protected]),
+  ets:insert(Kmodule, {types, Types}),
+  ets:insert(Kmodule, {specs, Specs}),
+  lists:foreach(fun({Mfa, Kfun}) -> ets:insert(Kmodule, {Mfa, Kfun}) end, Funs),
+  Kmodule.
+
+-spec kmodule_specs(kmodule()) -> cuter_types:stored_specs().
+kmodule_specs(Kmodule) ->
+  [{specs, Specs}] = ets:lookup(Kmodule, specs),
+  Specs.
+
+-spec kmodule_types(kmodule()) -> cuter_types:stored_types().
+kmodule_types(Kmodule) ->
+  [{types, Types}] = ets:lookup(Kmodule, types),
   Types.
+
+%% Retrieves the kfun() for the given MFA.
+-spec kmodule_kfun(kmodule(), mfa()) -> {ok, kfun()} | error.
+kmodule_kfun(Kmodule, Mfa) ->
+  case ets:lookup(Kmodule, Mfa) of
+    [] -> error;
+    [{Mfa, Kfun}] -> {ok, Kfun}
+  end.
+
+%% Retrieves the spec for the given MFA.
+-spec kmodule_mfa_spec(kmodule(), mfa()) -> {ok, cuter_types:stored_spec_value()} | error.
+kmodule_mfa_spec(Kmodule, {_M, F, A}) ->
+  cuter_types:find_spec({F, A}, kmodule_specs(Kmodule)).
+
+%% TODO(aggelos): Remove it when kmodule() becomes a map.
+-spec destroy_kmodule(kmodule()) -> ok.
+destroy_kmodule(Kmodule) ->
+  ets:delete(Kmodule),
+  ok.
 
 %% -------------------------------------------------------------------
 %% kfun API
@@ -178,26 +228,26 @@ kfun_is_exported(#{is_exported := IsExported}) -> IsExported.
 -spec kfun_code(kfun()) -> code().
 kfun_code(#{code := Code}) -> Code.
 
-%%====================================================================
+%% ===================================================================
 %% Internal functions
-%%====================================================================
+%% ===================================================================
 
-%% In each ModDb, the following information is saved:
-%% 
-%%       Key                  Value    
-%% -----------------    ---------------
-%% anno                 Anno :: []
-%% name                 Name :: module()
-%% exported             [{M :: module(), Fun :: atom(), Arity :: arity()}]
-%% attributes           Attrs :: [{cerl(), cerl()}]
-%% {M, Fun, Arity}      {Def :: #c_fun{}, Exported :: boolean()}
--spec store_module(cuter:mod(), cerl:cerl(), cuter_codeserver:module_cache(), tag_generator()) -> ok.
-store_module(M, AST, Cache, TagGen) ->
-  store_module_info(anno, M, AST, Cache),
-  store_module_info(name, M, AST, Cache),
-  store_module_info(exports, M, AST, Cache),
-  store_module_info(attributes, M, AST, Cache),
-  store_module_funs(M, AST, Cache, TagGen).
+-spec extract_exports(module(), ast()) -> [mfa()].
+extract_exports(M, AST) ->
+  Exports = cerl:module_exports(AST),
+  [mfa_from_var(M, E) || E <- Exports].
+
+-spec process_fundef({cerl:c_var(), code()}, [mfa()], module(), tag_generator()) -> {mfa(), kfun()}.
+process_fundef({FunVar, Def}, Exports, M, TagGen) ->
+  Mfa = mfa_from_var(M, FunVar),
+  IsExported = lists:member(Mfa, Exports),
+  AnnDef = annotate(Def, TagGen),
+  {Mfa, kfun(AnnDef, IsExported)}.
+
+-spec mfa_from_var(module(), cerl:c_var()) -> mfa().
+mfa_from_var(M, Var) ->
+  {F, A} = cerl:var_name(Var),
+  {M, F, A}.
 
 %% Gets the Core Erlang AST of a module.
 -spec get_core(cuter:mod(), boolean()) -> {ok, cerl:cerl()} | load_error().
@@ -238,52 +288,6 @@ get_abstract_code(Mod, Beam) ->
     {ok, {Mod, [{abstract_code, {_, AbstractCode}}]}} -> AbstractCode;
     _ -> throw(cuter_pp:abstract_code_missing(Mod))
   end.
-
-%% Store module information
--spec store_module_info(info(), cuter:mod(), cerl:c_module(), cuter_codeserver:module_cache()) -> ok.
-store_module_info(anno, _M, AST, Cache) ->
-  Anno = AST#c_module.anno,
-  cuter_codeserver:insert_in_module_cache(anno, Anno, Cache);
-store_module_info(attributes, _M, AST, Cache) ->
-  Attrs = cerl:module_attrs(AST),
-  cuter_codeserver:insert_in_module_cache(attributes, Attrs, Cache),
-  %% Retrieve the attributes that involve type & record declarations.
-  {TypeAttrs, SpecAttrs} = classify_attributes(Attrs),
-  %% Pre-process those declarations.
-  Types = cuter_types:retrieve_types(TypeAttrs),
-  cuter_codeserver:insert_in_module_cache(types, Types, Cache),
-  %% Just store the attributes that involve specs.
-  Specs = cuter_types:retrieve_specs(SpecAttrs),
-  cuter_codeserver:insert_in_module_cache(specs, Specs, Cache);
-store_module_info(exports, M, AST, Cache) ->
-  Exps_c = AST#c_module.exports,
-  Fun_info = 
-    fun(Elem) ->
-      {Fun, Arity} = Elem#c_var.name,
-      {M, Fun, Arity}
-    end,
-  Exps = [Fun_info(E) || E <- Exps_c],
-  cuter_codeserver:insert_in_module_cache(exported, Exps, Cache);
-store_module_info(name, _M, AST, Cache) ->
-  ModName_c = AST#c_module.name,
-  ModName = ModName_c#c_literal.val,
-  cuter_codeserver:insert_in_module_cache(name, ModName, Cache).
-
-%% Store exported functions of a module
--spec store_module_funs(cuter:mod(), cerl:cerl(), cuter_codeserver:module_cache(), tag_generator()) -> ok.
-store_module_funs(M, AST, Cache, TagGen) ->
-  Funs = AST#c_module.defs,
-  {ok, Exps} = cuter_codeserver:lookup_in_module_cache(exported, Cache),
-  lists:foreach(fun(X) -> store_fun(Exps, M, X, Cache, TagGen) end, Funs).
-
-%% Store the AST of a function
--spec store_fun([atom()], cuter:mod(), {cerl:c_var(), code()}, cuter_codeserver:module_cache(), tag_generator()) -> ok.
-store_fun(Exps, M, {Fun, Def}, Cache, TagGen) ->
-  {FunName, Arity} = Fun#c_var.name,
-  MFA = {M, FunName, Arity},
-  IsExported = lists:member(MFA, Exps),
-  AnnDef = annotate(Def, TagGen),
-  cuter_codeserver:insert_in_module_cache(MFA, kfun(AnnDef, IsExported), Cache).
 
 -type type_info() :: {'type', cerl_typedef()}
                    | {'record', cerl_recdef()}.

--- a/test/utest/include/types.hrl
+++ b/test/utest/include/types.hrl
@@ -1,0 +1,7 @@
+%% -*- erlang-indent-level: 2 -*-
+%%------------------------------------------------------------------------------
+
+%% Types for test generators.
+-type f_one() :: fun((any()) -> any()).
+-type setup() :: {setup, fun(() -> any()), f_one(), f_one()}.
+-type tgen() :: {nonempty_string(), setup()}.

--- a/test/utest/src/cuter_cerl_tests.erl
+++ b/test/utest/src/cuter_cerl_tests.erl
@@ -6,7 +6,7 @@
 -include("include/eunit_config.hrl").
 -include("include/cuter_macros.hrl").
 
--spec test() -> any().
+-spec test() -> ok | {error, any()}.
 
 -spec load_lists_module_test() -> any().
 load_lists_module_test() ->
@@ -65,7 +65,7 @@ generate_and_collect_tags_for_lists_module_test() ->
 %% kfun API
 %% -------------------------------------------------------------------
 
--spec construct_and_access_kfun_test() -> ok.
+-spec construct_and_access_kfun_test() -> any.
 construct_and_access_kfun_test() ->
   Code = cerl:c_fun([cerl:c_nil()], cerl:c_nil()),
   Kfun = cuter_cerl:kfun(Code, true),
@@ -77,7 +77,7 @@ construct_and_access_kfun_test() ->
 %% kmodule API
 %% -------------------------------------------------------------------
 
--spec construct_and_access_kmodule_test() -> ok.
+-spec construct_and_access_kmodule_test() -> any.
 construct_and_access_kmodule_test() ->
   Code = cerl:c_fun([cerl:c_nil()], cerl:c_nil()),
   Kfun = cuter_cerl:kfun(Code, true),

--- a/test/utest/src/cuter_codeserver_tests.erl
+++ b/test/utest/src/cuter_codeserver_tests.erl
@@ -4,12 +4,13 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("include/cuter_macros.hrl").
+-include_lib("test/utest/include/types.hrl").
 
 -spec test() -> ok | {error, any()}.  %% This should be provided by EUnit
 
 -define(MODS_LIST, [lists, dict, orddict, ets, os, string, filelib, beam_lib, cerl]).
 
--spec load_modules_test_() -> any().
+-spec load_modules_test_() -> tgen().
 load_modules_test_() ->
   Setup = fun setup/0,
   Cleanup = fun cleanup/1,
@@ -27,7 +28,7 @@ load_mod(Cs, M) ->
   {atom_to_list(M), ?_assertMatch({ok, _}, Rep)}.
 
 
--spec load_and_retrieve_test_() -> any().
+-spec load_and_retrieve_test_() -> tgen().
 load_and_retrieve_test_() ->
   Setup = fun setup/0,
   Cleanup = fun cleanup/1,
@@ -44,7 +45,7 @@ load_and_retrieve_test_() ->
   {"Query modules multiple times", {setup, Setup, Cleanup, Inst}}.
 
 
--spec get_mfa_spec_test_() -> any().
+-spec get_mfa_spec_test_() -> tgen().
 get_mfa_spec_test_() ->
   Setup = fun setup/0,
   Cleanup = fun cleanup/1,
@@ -67,7 +68,7 @@ get_mfa_spec_test_() ->
   end,
   {"Get specs of mfas", {setup, Setup, Cleanup, Inst}}.
 
--spec error_load_test_() -> term().
+-spec error_load_test_() -> tgen().
 error_load_test_() ->
   Setup = fun setup/0,
   Cleanup = fun cleanup/1,

--- a/test/utest/src/cuter_codeserver_tests.erl
+++ b/test/utest/src/cuter_codeserver_tests.erl
@@ -5,17 +5,11 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("include/cuter_macros.hrl").
 
--spec test() -> 'ok' | {'error', term()}.  %% This should be provided by EUnit
+-spec test() -> ok | {error, any()}.  %% This should be provided by EUnit
 
 -define(MODS_LIST, [lists, dict, orddict, ets, os, string, filelib, beam_lib, cerl]).
 
--type descr() :: nonempty_string().
--type f_one() :: fun((term()) -> term()).
--type setup() :: {'setup', fun(() -> term()), f_one(), f_one()}.
--type ret_t() :: {descr(), setup()}.
-
-%% Load modules
--spec load_modules_test_() -> ret_t().
+-spec load_modules_test_() -> any().
 load_modules_test_() ->
   Setup = fun setup/0,
   Cleanup = fun cleanup/1,
@@ -32,8 +26,8 @@ load_mod(Cs, M) ->
   Rep = cuter_codeserver:load(Cs, M),
   {atom_to_list(M), ?_assertMatch({ok, _}, Rep)}.
 
-%% Load & Retrieve modules
--spec load_and_retrieve_test_() -> ret_t().
+
+-spec load_and_retrieve_test_() -> any().
 load_and_retrieve_test_() ->
   Setup = fun setup/0,
   Cleanup = fun cleanup/1,
@@ -49,9 +43,9 @@ load_and_retrieve_test_() ->
   end,
   {"Query modules multiple times", {setup, Setup, Cleanup, Inst}}.
 
-%% Get the specs of mfas.
--spec get_spec_test_() -> ret_t().
-get_spec_test_() ->
+
+-spec get_mfa_spec_test_() -> any().
+get_mfa_spec_test_() ->
   Setup = fun setup/0,
   Cleanup = fun cleanup/1,
   Inst = fun(_) ->
@@ -73,7 +67,6 @@ get_spec_test_() ->
   end,
   {"Get specs of mfas", {setup, Setup, Cleanup, Inst}}.
 
-%% Erroneous modules
 -spec error_load_test_() -> term().
 error_load_test_() ->
   Setup = fun setup/0,
@@ -88,10 +81,9 @@ error_load_test_() ->
   end,
   {"Query invalid modules", {setup, Setup, Cleanup, Inst}}.
 
-
-%%====================================================================
+%% ===================================================================
 %% Helper functions
-%%====================================================================
+%% ===================================================================
 
 setup() ->
   cuter_config:start(),


### PR DESCRIPTION
Starting off with an implementation of
`  kmodule() :: ets:tid()`
for compatibility with the current code, but will change to
`  kmodule() :: #{ ... }`
in a follow-up PR.