### PR TITLE
Support spec definitions with Erlang maps (183)

### DIFF
--- a/include/cuter_types.hrl
+++ b/include/cuter_types.hrl
@@ -15,6 +15,7 @@
 -define(integer_tag, integer).
 -define(list_tag, list).
 -define(local_tag, local).
+-define(map_tag, map).
 -define(neg_inf, neg_inf).
 -define(nil_tag, nil).
 -define(nonempty_list_tag, nonempty_list).

--- a/priv/cuter_common.py
+++ b/priv/cuter_common.py
@@ -817,3 +817,29 @@ def get_typedef_definition(tdef):
         tdef : Spec.TypeDef
     """
     return tdef.definition
+
+def is_type_map(t):
+    """
+    Parameters
+        t : Spec.Type
+    """
+    return t.type == Spec.MAP
+
+def get_association_list_from_map(t):
+    """
+    Parameters
+        t : Spec.Type
+    """
+    assert is_type_map(t)
+    return t.association_list.associations
+
+def get_association_symbol(t):
+    """
+    Parameters
+        t : Spec.Association.Kind
+    """
+    return {
+        Spec.Association.Kind.UNKNOWN: "??",
+        Spec.Association.Kind.MANDATORY: ":=",
+        Spec.Association.Kind.OPTIONAL: "=>",
+    }[t]

--- a/priv/cuter_print.py
+++ b/priv/cuter_print.py
@@ -99,6 +99,13 @@ def pretty_type(d):
       args = cc.get_parameters_from_complete_fun(d)
       ret = cc.get_rettype_from_fun(d)
       return "fun(({}) -> {})".format(", ".join(map(pretty_type, args)), pretty_type(ret))
+    if cc.is_type_map(d):
+      associations = cc.get_association_list_from_map(d)
+      return "map({})".format(", ".join("{} {} {}".format(
+        pretty_type(assoc.from_type),
+        cc.get_association_symbol(assoc.kind),
+        pretty_type(assoc.to_type),
+      ) for assoc in associations))
 
 def print_cmd(entry, rev):
   tp = entry.type

--- a/priv/cuter_smt.py
+++ b/priv/cuter_smt.py
@@ -415,6 +415,10 @@ class ErlangSMT(cgs.AbstractErlangSolver):
 		elif cc.is_type_userdef(spec):
 			type_name = cc.get_type_name_of_userdef(spec)
 			return ["|{}|".format(type_name), var]
+		elif cc.is_type_map(spec):
+			# TODO(neoaggelos): https://github.com/cuter-testing/cuter/issues/183
+			# Support map types
+			pass
 		clg.debug_info("unknown spec: " + str(spec))
 		assert False
 

--- a/src/cuter_pp.erl
+++ b/src/cuter_pp.erl
@@ -1244,6 +1244,12 @@ pp_type(Type, FmtFn) ->
           Ts1 = [pp_type(T, StrFmtFn) || T <- Ts],
           FmtFn("{~s}", [string:join(Ts1, ", ")])
       end;
+    ?map_tag ->
+      AssocList = [
+        FmtFn("~s ~s ~s", [pp_type(From, StrFmtFn), assoc_type_op(AssocType), pp_type(To, StrFmtFn)])
+        || { AssocType, From, To } <- cuter_types:assocs_of_t_map(Type)
+      ],
+      FmtFn("#{~s}", [string:join(AssocList, ", ")]);
     ?union_tag ->
       Ts1 = [pp_type(T, StrFmtFn) || T <- cuter_types:elements_types_of_t_union(Type)],
       FmtFn("~s", [string:join(Ts1, " | ")]);
@@ -1262,6 +1268,12 @@ pp_range_bound(Limit) ->
       integer_to_list(cuter_types:integer_of_t_integer_lit(Limit));
     Kind when Kind =:= ?pos_inf orelse Kind =:= ?neg_inf ->
       ""
+  end.
+
+assoc_type_op(AssocType) ->
+  case AssocType of
+    map_field_assoc -> "=>";
+    map_field_exact -> ":="
   end.
 
 pp_typesig(Fun, FmtFn) ->

--- a/src/cuter_proto_spec.proto
+++ b/src/cuter_proto_spec.proto
@@ -22,6 +22,7 @@ message Spec {
         FUN = 14;
         CONS = 15;
         NTUPLE = 16;
+        MAP = 18;
         USERDEF = 17;
     }
 
@@ -63,11 +64,28 @@ message Spec {
             FunSig fun = 7;
             uint32 ntuple_size = 8;
             string type_name = 9;
+            AssociationList association_list = 10;
         }
     }
 
     message TypeList {
         repeated Type types = 1;
+    }
+    
+    message Association {
+        Type from_type = 1;
+        Type to_type = 2;
+        
+        enum Kind {
+            UNKNOWN = 0;
+            MANDATORY = 1;
+            OPTIONAL = 2;
+        }
+        Kind kind = 3;
+    }
+    
+    message AssociationList {
+        repeated Association associations = 1;
     }
 
     repeated FunSig clauses = 1;

--- a/src/cuter_serial.erl
+++ b/src/cuter_serial.erl
@@ -424,10 +424,27 @@ to_type(Type) ->
       Bounds = #'Spec.RangeBounds'{ lower_bound = to_range_bound(Lower)
                                   , upper_bound = to_range_bound(Upper)},
       #'Spec.Type'{type = 'RANGE', arg = {'range_bounds', Bounds}};
+    ?map_tag ->
+      #'Spec.Type'{
+        type = 'MAP',
+        arg = {'association_list', #'Spec.AssociationList'{associations = [
+          #'Spec.Association'{
+            kind = to_type_association_kind(Kind),
+            from_type = to_type(From),
+            to_type = to_type(To)
+          } || {Kind, From, To} <- cuter_types:assocs_of_t_map(Type)
+        ]}}
+      };
     ?function_tag ->
       #'Spec.Type'{type = 'FUN', arg = {'fun', to_typesig(Type)}};
     ?userdef_tag ->
       #'Spec.Type'{type = 'USERDEF', arg = {'type_name', cuter_types:name_of_t_userdef(Type)}}
+  end.
+
+to_type_association_kind(Kind) ->
+  case Kind of
+    map_field_assoc -> 'OPTIONAL';
+    map_field_exact -> 'MANDATORY'
   end.
 
 to_range_bound(Limit) ->

--- a/src/cuter_types.erl
+++ b/src/cuter_types.erl
@@ -8,14 +8,14 @@
 -export([params_of_t_function_det/1, ret_of_t_function/1, atom_of_t_atom_lit/1,
 	 integer_of_t_integer_lit/1, elements_type_of_t_list/1,
 	 elements_type_of_t_nonempty_list/1, elements_types_of_t_tuple/1,
-	 elements_types_of_t_union/1, bounds_of_t_range/1,
+   assocs_of_t_map/1, elements_types_of_t_union/1, bounds_of_t_range/1,
 	 segment_size_of_bitstring/1, is_generic_function/1,
 	 name_of_t_userdef/1]).
 
 -export([t_atom/0, t_atom_lit/1, t_any/0,
 	 t_binary/0, t_bitstring/0, t_bitstring/2, t_char/0, t_float/0,
          t_function/0, t_function/2, t_function/3,
-	 t_integer/0, t_integer_lit/1, t_list/0, t_list/1,
+	 t_integer/0, t_integer_lit/1, t_list/0, t_list/1, t_map/0, t_map/1,
          t_nonempty_list/1, t_nil/0, t_number/0, t_remote/3, t_string/0,
 	 t_tuple/0, t_tuple/1, t_union/1,
 	 t_range/2, t_pos_inf/0, t_neg_inf/0, t_userdef/1]).
@@ -42,13 +42,13 @@
 
 -type kind() :: ?any_tag | ?atom_lit_tag |?atom_tag | ?bitstring_tag
               | ?float_tag | ?function_tag | ?integer_lit_tag |?integer_tag
-	      | ?list_tag | ?local_tag | ?neg_inf | ?nil_tag
+	      | ?list_tag | ?local_tag | ?map_tag | ?neg_inf | ?nil_tag
 	      | ?nonempty_list_tag | ?pos_inf | ?range_tag | ?record_tag
 	      | ?remote_tag | ?tuple_tag | ?union_tag | ?userdef_tag
 	      | ?type_variable.
 -type rep()  :: atom() | bitstring_rep()
               | function_det_rep() | function_gen_rep()
-              | integer() | integer_range_rep() | local_rep()
+              | integer() | integer_range_rep() | local_rep() | map_rep()
               | record_rep() | remote_rep() | userdef_rep()
 	      | type_var() | raw_type() | [raw_type()].
 
@@ -85,6 +85,7 @@
                   | t_nonempty_list()     % nonempty_list(Type)
                   | t_union()             % Type1 | ... | TypeN
                   | t_range()             % Erlang_Integer..Erlang_Integer
+                  | t_map()               % map
                   | t_bitstring()         % <<_:M>>
                   | t_function()          % function() | Fun | BoundedFun
                   | t_userdef()           % User defined type.
@@ -154,6 +155,11 @@
 
 %% Type variable.
 -type t_type_var() :: #t{kind :: ?type_variable, rep :: type_var()}.
+
+%% Map types.
+-type t_map()                :: #t{kind :: ?map_tag, rep :: map_rep()}.
+-type map_rep()              :: list({map_field_assoc_type(), raw_type(), raw_type()}).
+-type map_field_assoc_type() :: (map_field_exact | map_field_assoc).
 
 %% ----------------------------------------------------------------------------
 %% How intermediate type & spec representations are stored.
@@ -385,8 +391,15 @@ t_from_form({type, _, record, [{atom, _, Name} | FieldTypes]}) ->
   Fields = [t_bound_field_from_form(F) || F <- FieldTypes],
   t_record(Name, Fields);
 %% Map
-t_from_form({type, _, map, _}=X) ->
-  throw({unsupported, X});
+t_from_form({type, _, map, any}) ->
+  t_map();
+t_from_form({type, _, map, AssocForms}) ->
+  t_map([
+    case AssocType of 
+      map_field_assoc -> {map_field_assoc, t_from_form(From), t_from_form(To)};
+      map_field_exact -> {map_field_exact, t_from_form(From), t_from_form(To)}
+    end || {type, _, AssocType, [From, To]} <- AssocForms
+  ]);
 %% local type
 t_from_form({Tag, _, Name, Types}) when Tag =:= type; Tag =:= user_type ->
   Ts = [t_from_form(T) || T <- Types],
@@ -564,6 +577,14 @@ t_function(Types, Ret, Constraints) ->
 t_userdef(Name) ->
   #t{kind = ?userdef_tag, rep = Name}.
 
+-spec t_map(map_rep()) -> t_map().
+t_map(Rep) ->
+  #t{kind = ?map_tag, rep = Rep}.
+
+-spec t_map() -> t_map().
+t_map() ->
+  t_map([]).
+
 %% Constructors that are essentially aliases.
 
 -spec t_boolean() -> t_union().
@@ -681,6 +702,10 @@ is_tvar_wild_card(#t{kind = ?type_variable, rep = {?type_var, Var}}) ->
 -spec name_of_t_userdef(t_userdef()) -> userdef_rep().
 name_of_t_userdef(#t{kind = ?userdef_tag, rep = Name}) ->
   Name.
+
+-spec assocs_of_t_map(t_map()) -> map_rep().
+assocs_of_t_map(#t{kind = ?map_tag, rep = Assocs}) ->
+  Assocs.
 
 %% ----------------------------------------------------------------------------
 %% Generic API for raw_type().

--- a/test/utest/src/cuter_types_tests.erl
+++ b/test/utest/src/cuter_types_tests.erl
@@ -58,6 +58,19 @@ parse_types({types_and_specs, Attrs}) ->
         ])
       , []
       }
+    },
+    {"t8()"
+    , {type, t8, 0}
+    , { cuter_types:t_map(), [] }
+    },
+    {"t9()"
+    , {type, t9, 0}
+    , { cuter_types:t_map([
+        { map_field_assoc, cuter_types:t_atom(), cuter_types:t_list(cuter_types:t_integer()) },
+        { map_field_exact, cuter_types:t_float(), cuter_types:t_float() }
+        ])
+      , []
+    }
     }
   ],
   [{Txt, ?_assertEqual(Expected, dict:fetch(Key, Types))} || {Txt, Key, Expected} <- Ts].

--- a/test/utest/src/types_and_specs.erl
+++ b/test/utest/src/types_and_specs.erl
@@ -2,7 +2,7 @@
 
 -export([foo/0, f11/1, f12/1]).
 
--export_type([t1/0, t2/0, t3/0, t4/0, t5/0, t7/0]).
+-export_type([t1/0, t2/0, t3/0, t4/0, t5/0, t7/0, t8/0, t9/0]).
 
 -type t1() :: atom().
 -type t2() :: {integer(), float(), tuple()}.
@@ -11,6 +11,8 @@
 -type t5() :: {binary(), [number(), ...], string(), char()}.
 -type t6() :: types_and_specs2:e1(float()).
 -type t7() :: <<_:64>> | <<_:_*3>> | <<_:128, _:_*12>>.
+-type t8() :: map().
+-type t9() :: #{atom() => list(integer()), float() := float()}.
 
 -spec foo() -> ok.
 foo() -> ok.


### PR DESCRIPTION
### Summary

References #183 

Add support for Erlang map type definitions in function specs.

### Changes

- Add new ?map_tag macro definition
- Introduce Spec.{Association, AssociationList} messages
- Introduce 'MAP' value for Spec.Type enum
- Add new cuter_type t_map/0 and t_map/1
- Support map type in t_from_form
- Encode map specs and send to Python
- Add TODO for how the smt library can handle maps (will be added later)
- Add unit tests for parsing specs containing map types
- Support pretty printing map specs.

### Implementation notes

- We do keep track of mandatory vs optional type associations for the map. 
- I have attempted to follow existing local code conventions as much as possible.
- Cuter still does not work well with map types (in fact, it still crashes when a map expression is found), but can now properly recognise map types in specs.
- Regarding `enum Spec.Association.Kind`: While using a boolean field for mandatory vs optional associations feels quite natural, Erlang makes it a point to use enum values instead (e.g. `:=` and `=>` operators, `map_field_assoc` and `map_field_exact` atoms, etc). Hence the choice of using an enum instead.
- Regarding `Spec.AssociationList`: We could avoid the definition and simply define `repeated Association association_list`. Decided against it to follow suit with `Spec.TypeList`.

### Unit tests

- Added two new unit tests for parsing `map` type definitions.

### Testing

With the following code snippet:

```erlang
%% the spec is all we are interested in at the moment
-spec my_function(#{integer() => integer(), float() := float()}) -> integer().
my_function(M) ->
  ok.
```

**Before the changes**, cuter simply crashes, since `map` types were not supported.

**After the changes**:

```bash
# cuter can understand the function spec.
$ ./cuter -pa ./ebin/ -pa ./mytests/ --fully-verbose -ds --debug-keep-traces my_module my_function '[1]'
Loading module cuter_erlang.
Loading module my_module.
Testing module:my_function/1 ...
my_module:my_function/1
    Spec:
        fun((#{integer() => integer(), float() := float()}) -> integer())
......

# the function spec is properly passed to the statement engine (which cries wolf because support is not implemented yet)
$ tail -f debug.log
unknown spec: type: MAP
association_list {
  associations {
    from {
      type: INTEGER
    }
    to {
      type: INTEGER
    }
    kind: OPTIONAL
  }
  associations {
    from {
      type: FLOAT
    }
    to {
      type: FLOAT
    }
    kind: MANDATORY
  }
}

# print the debug trace:
$ ./priv/cuter_print.py /path/to/temp/traces/$TRACE/$PROC
PARAMS
  x1
SPEC
  (map(integer => integer, float := float)) -> integer
```