### PR TITLE
Extend cuter_eval with option to conditionally log branches

### DIFF
--- a/src/cuter_eval.erl
+++ b/src/cuter_eval.erl
@@ -36,6 +36,9 @@
 }).
 -type valuelist() :: #valuelist{}.
 
+%% Runtime options for the evaluator function of the interpreter.
+-type eval_opts() :: #{constraintLogging := boolean()}.
+
 %% ----------------------------------------------------------------------------
 %% Types and macros used for storing the information of applying a lambda
 %% that has a symbolic value.
@@ -142,11 +145,12 @@ log_mfa_spec(_, _, _) -> ok.
 eval(A, CAs, SAs, CallType, Servers, Fd) ->
   DefaultOptions = #{constraintLogging => true},
   eval(A, CAs, SAs, CallType, Servers, Fd, DefaultOptions).
+
 %% Handle spawns so that the spawned process will be interpreted
 %% and not directly executed
 
 %% spawn/{1,2,3,4} & spawn_link/{1,2,3,4}
--spec eval(eval(), [any()], [any()], calltype(), servers(), file:io_device(), maps:map()) -> result().
+-spec eval(eval(), [any()], [any()], calltype(), servers(), file:io_device(), eval_opts()) -> result().
 eval({named, erlang, F}, CAs, SAs, _CallType, Servers, Fd, Options) when F =:= spawn; F =:= spawn_link ->
   Arity = length(CAs),
   SAs_e = cuter_symbolic:ensure_list(SAs, Arity, Fd),
@@ -509,7 +513,9 @@ eval({letrec_func, {M, _F, Def, E}}, CAs, SAs, _CallType, Servers, Fd, Options) 
 %%
 %% Evaluates a Core Erlang expression
 %% --------------------------------------------------------
--spec eval_expr(cerl:cerl(), module(), cuter_env:environment(), cuter_env:environment(), servers(), file:io_device(), maps:map()) -> result().
+-spec eval_expr(cerl:cerl(), module(), cuter_env:environment(),
+                cuter_env:environment(), servers(), file:io_device(),
+                eval_opts()) -> result().
 
 %% c_apply
 eval_expr({c_apply, _Anno, Op, Args}, M, Cenv, Senv, Servers, Fd, Options) ->

--- a/src/cuter_eval.erl
+++ b/src/cuter_eval.erl
@@ -1958,9 +1958,8 @@ log_bistr_type_mismatch(Cv, Sv, Type, Fd) ->
   end.
 
 log(Fn, Options) ->
+  %% TODO(dspil): Add the clause for the false value. It does not exist for now to silence dialyzer.
   case maps:get(constraintLogging, Options) of
     true ->
-      Fn();
-    false ->
-      ok
+      Fn()
   end.

--- a/src/cuter_eval.erl
+++ b/src/cuter_eval.erl
@@ -139,12 +139,15 @@ log_mfa_spec(_, _, _) -> ok.
 %% Concrete/Symbolic Evaluation and Logging of an MFA call
 %% -------------------------------------------------------------------
 -spec eval(eval(), [any()], [any()], calltype(), servers(), file:io_device()) -> result().
-
+eval(A, CAs, SAs, CallType, Servers, Fd) ->
+  DefaultOptions = #{constraintLogging => true},
+  eval(A, CAs, SAs, CallType, Servers, Fd, DefaultOptions).
 %% Handle spawns so that the spawned process will be interpreted
 %% and not directly executed
 
 %% spawn/{1,2,3,4} & spawn_link/{1,2,3,4}
-eval({named, erlang, F}, CAs, SAs, _CallType, Servers, Fd) when F =:= spawn; F =:= spawn_link ->
+-spec eval(eval(), [any()], [any()], calltype(), servers(), file:io_device(), maps:map()) -> result().
+eval({named, erlang, F}, CAs, SAs, _CallType, Servers, Fd, Options) when F =:= spawn; F =:= spawn_link ->
   Arity = length(CAs),
   SAs_e = cuter_symbolic:ensure_list(SAs, Arity, Fd),
   Rf = erlang:make_ref(),
@@ -183,12 +186,12 @@ eval({named, erlang, F}, CAs, SAs, _CallType, Servers, Fd) when F =:= spawn; F =
     end,
   receive
     {ChildP, registered} ->
-      cuter_log:log_spawn(Fd, ChildP, Rf),
+      conditional_log(fun cuter_log:log_spawn/3, [Fd, ChildP, Rf], Options),
       mk_result(ChildP, ChildP)
   end;
 
 %% spawn_monitor/{1,3}
-eval({named, erlang, spawn_monitor}, CAs, SAs, _CallType, Servers, Fd) ->
+eval({named, erlang, spawn_monitor}, CAs, SAs, _CallType, Servers, Fd, Options) ->
   Arity = length(CAs),
   SAs_e = cuter_symbolic:ensure_list(SAs, Arity, Fd),
   Rf = erlang:make_ref(),
@@ -210,12 +213,12 @@ eval({named, erlang, spawn_monitor}, CAs, SAs, _CallType, Servers, Fd) ->
   {ChildP, _ChildRef} = CC = erlang:spawn_monitor(Child),
   receive
     {ChildP, registered} ->
-      cuter_log:log_spawn(Fd, ChildP, Rf),
+      conditional_log(fun cuter_log:log_spawn/3, [Fd, ChildP, Rf], Options),
       mk_result(CC, CC)
   end;
 
 %% spawn_opt/{1,3,4,5}
-eval({named, erlang, spawn_opt}, CAs, SAs, _CallType, Servers, Fd) ->
+eval({named, erlang, spawn_opt}, CAs, SAs, _CallType, Servers, Fd, Options) ->
   Arity = length(CAs),
   SAs_e = cuter_symbolic:ensure_list(SAs, Arity, Fd),
   Rf = erlang:make_ref(),
@@ -259,7 +262,7 @@ eval({named, erlang, spawn_opt}, CAs, SAs, _CallType, Servers, Fd) ->
     end,
   receive
     {ChildP, registered} ->
-      cuter_log:log_spawn(Fd, ChildP, Rf),
+      conditional_log(fun cuter_log:log_spawn/3, [Fd, ChildP, Rf], Options),
       mk_result(R, R)
   end;
 
@@ -267,11 +270,11 @@ eval({named, erlang, spawn_opt}, CAs, SAs, _CallType, Servers, Fd) ->
 %% so as to zip the concrete and symbolic message
 
 %% Redirect erlang:'!'/2 to erlang:send/2
-eval({named, erlang, '!'}, [_, _] = CAs, SAs, CallType, Servers, Fd) ->
-  eval({named, erlang, send}, CAs, SAs, CallType, Servers, Fd);
+eval({named, erlang, '!'}, [_, _] = CAs, SAs, CallType, Servers, Fd, Options) ->
+  eval({named, erlang, send}, CAs, SAs, CallType, Servers, Fd, Options);
 
 %% send/{2,3}
-eval({named, erlang, send}, CAs, SAs, _CallType, Servers, Fd) ->
+eval({named, erlang, send}, CAs, SAs, _CallType, Servers, Fd, _) ->
   Arity = length(CAs),
   SAs_e = cuter_symbolic:ensure_list(SAs, Arity, Fd),
   case CAs of
@@ -294,7 +297,7 @@ eval({named, erlang, send}, CAs, SAs, _CallType, Servers, Fd) ->
   end;
 
 %% send_after/3
-eval({named, erlang, send_after}, CAs, SAs, _CallType, Servers, Fd) ->
+eval({named, erlang, send_after}, CAs, SAs, _CallType, Servers, Fd, _Options) ->
   Arity = length(CAs),
   SAs_e = cuter_symbolic:ensure_list(SAs, Arity, Fd),
   case CAs of
@@ -310,7 +313,7 @@ eval({named, erlang, send_after}, CAs, SAs, _CallType, Servers, Fd) ->
   end;
 
 %% send_nosuspend/{2,3}
-eval({named, erlang, send_nosuspend}, CAs, SAs, _CallType, Servers, Fd) ->
+eval({named, erlang, send_nosuspend}, CAs, SAs, _CallType, Servers, Fd, _Options) ->
   Arity = length(CAs),
   SAs_e = cuter_symbolic:ensure_list(SAs, Arity, Fd),
   case CAs of
@@ -336,7 +339,7 @@ eval({named, erlang, send_nosuspend}, CAs, SAs, _CallType, Servers, Fd) ->
 %% so as to zip the concrete and symbolic reason
 
 %% throw/1
-eval({named, erlang, throw}, CAs, SAs, _CallType, _Servers, Fd) ->
+eval({named, erlang, throw}, CAs, SAs, _CallType, _Servers, Fd, _Options) ->
   Arity = length(CAs),
   SAs_e = cuter_symbolic:ensure_list(SAs, Arity, Fd),
   case CAs of
@@ -349,7 +352,7 @@ eval({named, erlang, throw}, CAs, SAs, _CallType, _Servers, Fd) ->
   end;
 
 %% exit/{1,2}
-eval({named, erlang, exit}, CAs, SAs, _CallType, _Servers, Fd) ->
+eval({named, erlang, exit}, CAs, SAs, _CallType, _Servers, Fd, _Options) ->
   Arity = length(CAs),
   SAs_e = cuter_symbolic:ensure_list(SAs, Arity, Fd),
   case CAs of
@@ -380,7 +383,7 @@ eval({named, erlang, exit}, CAs, SAs, _CallType, _Servers, Fd) ->
   end;
 
 %% error/{1,2}
-eval({named, erlang, error}, CAs, SAs, _CallType, _Servers, Fd) ->
+eval({named, erlang, error}, CAs, SAs, _CallType, _Servers, Fd, _Options) ->
   Arity = length(CAs),
   SAs_e = cuter_symbolic:ensure_list(SAs, Arity, Fd),
   case CAs of
@@ -398,7 +401,7 @@ eval({named, erlang, error}, CAs, SAs, _CallType, _Servers, Fd) ->
   end;
 
 %% raise/3
-eval({named, erlang, raise}, CAs, SAs, _CallType, _Servers, Fd) ->
+eval({named, erlang, raise}, CAs, SAs, _CallType, _Servers, Fd, _Options) ->
   Arity = length(CAs),
   SAs_e = cuter_symbolic:ensure_list(SAs, Arity, Fd),
   case CAs of
@@ -414,30 +417,30 @@ eval({named, erlang, raise}, CAs, SAs, _CallType, _Servers, Fd) ->
 %% Handle other important functions
 
 %% make_fun/3
-eval({named, erlang, make_fun}, CAs, SAs, _CallType, Servers, Fd) ->
+eval({named, erlang, make_fun}, CAs, SAs, _CallType, Servers, Fd, Options) ->
   Arity = length(CAs),
   _ = cuter_symbolic:ensure_list(SAs, Arity, Fd),
   case CAs of
     [M, F, A] ->
-      make_fun(M, F, A, Servers, Fd);
+      make_fun(M, F, A, Servers, Fd, Options);
     _ ->
       exception(error, {undef, {erlang, make_fun, Arity}})
   end;
 
 %% apply/{2,3}
-eval({named, erlang, apply}, CAs, SAs, _CallType, Servers, Fd) ->
+eval({named, erlang, apply}, CAs, SAs, _CallType, Servers, Fd, Options) ->
   Arity = length(CAs),
   SAs_e = cuter_symbolic:ensure_list(SAs, Arity, Fd),
   case CAs of
     [Fun, Args] ->
       [SFun, SArgs] = SAs_e,
       %% Constraint: Fun=SFun
-      eval({lambda, Fun, SFun}, Args, SArgs, local, Servers, Fd);
+      eval({lambda, Fun, SFun}, Args, SArgs, local, Servers, Fd, Options);
     [M, F, Args] ->
       [_SMod, _SFun, SArgs] = SAs_e,
       %% Constraints: SMod = M, SFun=F
       Call = find_call_type(erlang, M),
-      eval({named, M, F}, Args, SArgs, Call, Servers, Fd);
+      eval({named, M, F}, Args, SArgs, Call, Servers, Fd, Options);
     _ ->
       exception(error, {undef, {erlang, apply, Arity}})
   end;
@@ -445,7 +448,7 @@ eval({named, erlang, apply}, CAs, SAs, _CallType, Servers, Fd) ->
 %% Generic case
 
 %% Handle an MFA
-eval({named, M, F}, CAs_b, SAs_b, CallType, Servers, Fd) ->
+eval({named, M, F}, CAs_b, SAs_b, CallType, Servers, Fd, Options) ->
   {CAs, SAs} = adjust_arguments(M, F, CAs_b, SAs_b, Fd),
   Arity = length(CAs),
   SAs_e = cuter_symbolic:ensure_list(SAs, Arity, Fd),
@@ -460,11 +463,11 @@ eval({named, M, F}, CAs_b, SAs_b, CallType, Servers, Fd) ->
       NSenv = cuter_env:new_environment(),
       Cenv = cuter_env:bind_parameters(CAs, Code#c_fun.vars, NCenv),
       Senv = cuter_env:bind_parameters(SAs_e, Code#c_fun.vars, NSenv),
-      eval_expr(Code#c_fun.body, NM, Cenv, Senv, Servers, Fd)
+      eval_expr(Code#c_fun.body, NM, Cenv, Senv, Servers, Fd, Options)
   end;
 
 %% Handle a Closure
-eval({lambda, Closure, ClosureSymb}, CAs, SAs, _CallType, _Servers, Fd) ->
+eval({lambda, Closure, ClosureSymb}, CAs, SAs, _CallType, _Servers, Fd, Options) ->
   Arity = length(CAs),
   SAs_e = cuter_symbolic:ensure_list(SAs, Arity, Fd),
   ZAs = zip_args(CAs, SAs_e),
@@ -487,42 +490,42 @@ eval({lambda, Closure, ClosureSymb}, CAs, SAs, _CallType, _Servers, Fd) ->
               mk_result(Cv, R);
             true ->
               Sv = get_symbolic(Cv),
-              cuter_log:log_evaluated_closure(Fd, ClosureSymb, SAs_e, Sv),
+              conditional_log(fun cuter_log:log_evaluated_closure/4, [Fd, ClosureSymb, SAs_e, Sv], Options),
               Cv
           end
       end
   end;
 
 %% Handle a function bound in a letrec expression
-eval({letrec_func, {M, _F, Def, E}}, CAs, SAs, _CallType, Servers, Fd) ->
+eval({letrec_func, {M, _F, Def, E}}, CAs, SAs, _CallType, Servers, Fd, Options) ->
   {Cenv, Senv} = E(),
   SAs_e = cuter_symbolic:ensure_list(SAs, length(CAs), Fd),
   NCenv = cuter_env:bind_parameters(CAs, Def#c_fun.vars, Cenv),
   NSenv = cuter_env:bind_parameters(SAs_e, Def#c_fun.vars, Senv),
-  eval_expr(Def#c_fun.body, M, NCenv, NSenv, Servers, Fd).
+  eval_expr(Def#c_fun.body, M, NCenv, NSenv, Servers, Fd, Options).
 
 %% --------------------------------------------------------
 %% eval_expr
 %%
 %% Evaluates a Core Erlang expression
 %% --------------------------------------------------------
--spec eval_expr(cerl:cerl(), module(), cuter_env:environment(), cuter_env:environment(), servers(), file:io_device()) -> result().
+-spec eval_expr(cerl:cerl(), module(), cuter_env:environment(), cuter_env:environment(), servers(), file:io_device(), maps:map()) -> result().
 
 %% c_apply
-eval_expr({c_apply, _Anno, Op, Args}, M, Cenv, Senv, Servers, Fd) ->
-  Op_ev = eval_expr(Op, M, Cenv, Senv, Servers, Fd),
+eval_expr({c_apply, _Anno, Op, Args}, M, Cenv, Senv, Servers, Fd, Options) ->
+  Op_ev = eval_expr(Op, M, Cenv, Senv, Servers, Fd, Options),
   Fun =
     fun(A) ->
-      A_ev = eval_expr(A, M, Cenv, Senv, Servers, Fd),
+      A_ev = eval_expr(A, M, Cenv, Senv, Servers, Fd, Options),
       %% Will create closures where appropriate
       case get_concrete(A_ev) of
         {?FUNCTION_PREFIX, {F, Arity}} ->
           %% local func (external func is already in make_fun/3 in core erlang)
-          create_closure(M, F, Arity, local, Servers, Fd);
+          create_closure(M, F, Arity, local, Servers, Fd, Options);
         {letrec_func, {Mod, F, Arity, Def, E}} ->
           %% letrec func
           {Ce, Se} = E(),
-          create_closure(Mod, F, Arity, {letrec_func, {Def, Ce, Se}}, Servers, Fd);
+          create_closure(Mod, F, Arity, {letrec_func, {Def, Ce, Se}}, Servers, Fd, Options);
         _ ->
           A_ev
       end
@@ -531,37 +534,37 @@ eval_expr({c_apply, _Anno, Op, Args}, M, Cenv, Senv, Servers, Fd) ->
   {CAs, SAs} = cuter_lib:unzip_with(fun to_tuple/1, ZAs),
   case get_concrete(Op_ev) of % See eval_expr(#c_var{}, ...) output for reference
     {?FUNCTION_PREFIX, {Func, _Arity}} ->
-      eval({named, M, Func}, CAs, SAs, local, Servers, Fd);
+      eval({named, M, Func}, CAs, SAs, local, Servers, Fd, Options);
     {letrec_func, {Mod, Func, _Arity, Def, E}} ->
-      eval({letrec_func, {Mod, Func, Def, E}}, CAs, SAs, local, Servers, Fd);
+      eval({letrec_func, {Mod, Func, Def, E}}, CAs, SAs, local, Servers, Fd, Options);
     Closure ->
       %% Constraint OP_s = OP_c (in case closure is made by make_fun)
-      eval({lambda, Closure, get_symbolic(Op_ev)}, CAs, SAs, local, Servers, Fd)
+      eval({lambda, Closure, get_symbolic(Op_ev)}, CAs, SAs, local, Servers, Fd, Options)
   end;
 
 %% c_binary
 %% TODO Use the tags of segments.
-eval_expr({c_binary, _Anno, Segments}, M, Cenv, Senv, Servers, Fd) ->
-  Segs = [eval_expr(S, M, Cenv, Senv, Servers, Fd) || S <- Segments],
+eval_expr({c_binary, _Anno, Segments}, M, Cenv, Senv, Servers, Fd, Options) ->
+  Segs = [eval_expr(S, M, Cenv, Senv, Servers, Fd, Options) || S <- Segments],
   {Cs, Ss} = cuter_lib:unzip_with(fun to_tuple/1, Segs),
   append_segments(Cs, Ss, Fd);
 
 %% c_bitstr
-eval_expr({c_bitstr, _Anno, Val, Size, Unit, Type, Flags}, M, Cenv, Senv, Servers, Fd) ->
+eval_expr({c_bitstr, _Anno, Val, Size, Unit, Type, Flags}, M, Cenv, Senv, Servers, Fd, Options) ->
   %% Evaluate the value and the encoding.
-  Val_ev = eval_expr(Val, M, Cenv, Senv, Servers, Fd),
+  Val_ev = eval_expr(Val, M, Cenv, Senv, Servers, Fd, Options),
   Val_c = get_concrete(Val_ev),
   Val_s = get_symbolic(Val_ev),
-  Size_ev = eval_expr(Size, M, Cenv, Senv, Servers, Fd),
-  Unit_ev = eval_expr(Unit, M, Cenv, Senv, Servers, Fd),
-  Type_ev = eval_expr(Type, M, Cenv, Senv, Servers, Fd),
-  Flags_ev = eval_expr(Flags, M, Cenv, Senv, Servers, Fd),
+  Size_ev = eval_expr(Size, M, Cenv, Senv, Servers, Fd, Options),
+  Unit_ev = eval_expr(Unit, M, Cenv, Senv, Servers, Fd, Options),
+  Type_ev = eval_expr(Type, M, Cenv, Senv, Servers, Fd, Options),
+  Flags_ev = eval_expr(Flags, M, Cenv, Senv, Servers, Fd, Options),
   Size_c = get_concrete(Size_ev),
   Size_s = get_symbolic(Size_ev),
   %% Log constraints on type mismatch before construction.
-  log_bistr_type_mismatch(Val_c, Val_s, Type, Fd), % Type is always a literal.
+  conditional_log(fun log_bistr_type_mismatch/4, [Val_c, Val_s, Type, Fd], Options),  % Type is always a literal.
   %% Log constraints on negative sizes before construction.
-  log_bitstr_neg_size(Size_c, Size_s, Fd),
+  conditional_log(fun log_bitstr_neg_size/3, [Size_c, Size_s, Fd], Options),
   %% Generate the concrete value.
   Bin_c = cuter_binlib:make_bitstring(Val_c, Size_c,
     get_concrete(Unit_ev), get_concrete(Type_ev), get_concrete(Flags_ev)),
@@ -573,21 +576,21 @@ eval_expr({c_bitstr, _Anno, Val, Size, Unit, Type, Flags}, M, Cenv, Senv, Server
   mk_result(Bin_c, Bin_s);
 
 %% c_call
-eval_expr({c_call, _Anno, Mod, Name, Args}, M, Cenv, Senv, Servers, Fd) ->
-  Mod_ev = eval_expr(Mod, M, Cenv, Senv, Servers, Fd),
-  Fv_ev = eval_expr(Name, M, Cenv, Senv, Servers, Fd),
+eval_expr({c_call, _Anno, Mod, Name, Args}, M, Cenv, Senv, Servers, Fd, Options) ->
+  Mod_ev = eval_expr(Mod, M, Cenv, Senv, Servers, Fd, Options),
+  Fv_ev = eval_expr(Name, M, Cenv, Senv, Servers, Fd, Options),
   Fun =
     fun(A) ->
-      A_ev = eval_expr(A, M, Cenv, Senv, Servers, Fd),
+      A_ev = eval_expr(A, M, Cenv, Senv, Servers, Fd, Options),
       %% Will create closures where appropriate
       case get_concrete(A_ev) of
         {?FUNCTION_PREFIX, {F, Arity}} ->
           %% local func (external func is already in make_fun/3 in core erlang)
-          create_closure(M, F, Arity, local, Servers, Fd);
+          create_closure(M, F, Arity, local, Servers, Fd, Options);
         {letrec_func, {Mod, F, Arity, Def, E}} ->
           %% letrec func
           {Ce, Se} = E(),
-          create_closure(Mod, F, Arity, {letrec_func, {Def, Ce, Se}}, Servers, Fd);
+          create_closure(Mod, F, Arity, {letrec_func, {Def, Ce, Se}}, Servers, Fd, Options);
         _ ->
           A_ev
       end
@@ -596,20 +599,20 @@ eval_expr({c_call, _Anno, Mod, Name, Args}, M, Cenv, Senv, Servers, Fd) ->
   {CAs, SAs} = cuter_lib:unzip_with(fun to_tuple/1, ZAs),
   %% Constraints Mod_c = Mod_s and Fv_c = Fv_s
   Mod_c = get_concrete(Mod_ev),
-  eval({named, Mod_c, get_concrete(Fv_ev)}, CAs, SAs, find_call_type(M, Mod_c), Servers, Fd);
+  eval({named, Mod_c, get_concrete(Fv_ev)}, CAs, SAs, find_call_type(M, Mod_c), Servers, Fd, Options);
 
 %% c_case
-eval_expr({c_case, _Anno, Arg, Clauses}, M, Cenv, Senv, Servers, Fd) ->
-  Arg_ev = eval_expr(Arg, M, Cenv, Senv, Servers, Fd),
-  {Body, Ce, Se, _Cnt} = find_clause(Clauses, M, 'case', get_concrete(Arg_ev), get_symbolic(Arg_ev), Cenv, Senv, Servers, Fd),
+eval_expr({c_case, _Anno, Arg, Clauses}, M, Cenv, Senv, Servers, Fd, Options) ->
+  Arg_ev = eval_expr(Arg, M, Cenv, Senv, Servers, Fd, Options),
+  {Body, Ce, Se, _Cnt} = find_clause(Clauses, M, 'case', get_concrete(Arg_ev), get_symbolic(Arg_ev), Cenv, Senv, Servers, Fd, Options),
   cuter_log:reduce_constraint_counter(), % TODO Should also add this call to c_receive
-  eval_expr(Body, M, Ce, Se, Servers, Fd);
+  eval_expr(Body, M, Ce, Se, Servers, Fd, Options);
 
 %% c_catch
 %% Commented code: allow the exceptions to propagate
-eval_expr({c_catch, _Anno, Body}, M, Cenv, Senv, Servers, Fd) ->
+eval_expr({c_catch, _Anno, Body}, M, Cenv, Senv, Servers, Fd, Options) ->
   try
-    eval_expr(Body, M, Cenv, Senv, Servers, Fd)
+    eval_expr(Body, M, Cenv, Senv, Servers, Fd, Options)
   catch
     throw:Throw ->
       unzip_one(Throw);
@@ -633,22 +636,22 @@ eval_expr({c_catch, _Anno, Body}, M, Cenv, Senv, Servers, Fd) ->
 %%  eval_expr(Body, M, Cenv, Senv, Servers, Fd);
 
 %% c_cons
-eval_expr({c_cons, _Anno, Hd, Tl}, M, Cenv, Senv, Servers, Fd) ->
-  Hd_ev = eval_expr(Hd, M, Cenv, Senv, Servers, Fd),
-  Tl_ev = eval_expr(Tl, M, Cenv, Senv, Servers, Fd),
+eval_expr({c_cons, _Anno, Hd, Tl}, M, Cenv, Senv, Servers, Fd, Options) ->
+  Hd_ev = eval_expr(Hd, M, Cenv, Senv, Servers, Fd, Options),
+  Tl_ev = eval_expr(Tl, M, Cenv, Senv, Servers, Fd, Options),
   Cv = [get_concrete(Hd_ev) | get_concrete(Tl_ev)],
   Sv = cuter_symbolic:cons(get_symbolic(Hd_ev), get_symbolic(Tl_ev), Cv, Fd),
   mk_result(Cv, Sv);
 
 %% c_fun
-eval_expr({c_fun, _Anno, Vars, Body}, M, Cenv, Senv, Servers, Fd) ->
+eval_expr({c_fun, _Anno, Vars, Body}, M, Cenv, Senv, Servers, Fd, Options) ->
   Arity = length(Vars),
-  make_fun(Vars, Body, M, Arity, Cenv, Senv, Servers, Fd);
+  make_fun(Vars, Body, M, Arity, Cenv, Senv, Servers, Fd, Options);
 
 %% c_let
-eval_expr({c_let, _Anno, Vars, Arg, Body}, M, Cenv, Senv, Servers, Fd) ->
+eval_expr({c_let, _Anno, Vars, Arg, Body}, M, Cenv, Senv, Servers, Fd, Options) ->
   Deg = length(Vars),
-  Arg_ev = eval_expr(Arg, M, Cenv, Senv, Servers, Fd),
+  Arg_ev = eval_expr(Arg, M, Cenv, Senv, Servers, Fd, Options),
   Arg_c = get_concrete(Arg_ev),
   Arg_s = get_symbolic(Arg_ev),
   case Deg of
@@ -661,10 +664,10 @@ eval_expr({c_let, _Anno, Vars, Arg, Body}, M, Cenv, Senv, Servers, Fd) ->
   end,
   Ce = cuter_env:bind_parameters(CAs, Vars, Cenv),
   Se = cuter_env:bind_parameters(SAs, Vars, Senv),
-  eval_expr(Body, M, Ce, Se, Servers, Fd);
+  eval_expr(Body, M, Ce, Se, Servers, Fd, Options);
 
 %% c_letrec
-eval_expr({c_letrec, _Anno, Defs, Body}, M, Cenv, Senv, Servers, Fd) ->
+eval_expr({c_letrec, _Anno, Defs, Body}, M, Cenv, Senv, Servers, Fd, Options) ->
   H = fun(F) -> fun() ->
     lists:foldl(
       fun({Func, Def}, {E_c, E_s}) ->
@@ -680,10 +683,10 @@ eval_expr({c_letrec, _Anno, Defs, Body}, M, Cenv, Senv, Servers, Fd) ->
     )
   end end,
   {NCe, NSe} = (y(H))(),
-  eval_expr(Body, M, NCe, NSe, Servers, Fd);
+  eval_expr(Body, M, NCe, NSe, Servers, Fd, Options);
 
 %% c_literal
-eval_expr({c_literal, _Anno, V}, _M, _Cenv, _Senv, Servers, Fd) ->
+eval_expr({c_literal, _Anno, V}, _M, _Cenv, _Senv, Servers, Fd, Options) ->
   case erlang:is_function(V) of
     false -> mk_result(V, V);
     true ->
@@ -698,15 +701,15 @@ eval_expr({c_literal, _Anno, V}, _M, _Cenv, _Senv, Servers, Fd) ->
 	      mk_result(V, LambdaS);
 	    Mod ->
 	      Func = proplists:get_value(name, Info),
-	      make_fun(Mod, Func, Arity, Servers, Fd)
+	      make_fun(Mod, Func, Arity, Servers, Fd, Options)
 	  end
       end
   end;
 
 %% c_primop
-eval_expr({c_primop, _Anno, Name, Args}, M, Cenv, Senv, Servers, Fd) ->
+eval_expr({c_primop, _Anno, Name, Args}, M, Cenv, Senv, Servers, Fd, Options) ->
   PrimOp = Name#c_literal.val,
-  ZAs = [eval_expr(A, M, Cenv, Senv, Servers, Fd) || A <- Args],
+  ZAs = [eval_expr(A, M, Cenv, Senv, Servers, Fd, Options) || A <- Args],
   {CAs, SAs} = cuter_lib:unzip_with(fun to_tuple/1, ZAs),
   %% TODO need to record and implement more primops
   %% like 'bs_context_to_binary', 'bs_init_writable'
@@ -715,44 +718,44 @@ eval_expr({c_primop, _Anno, Name, Args}, M, Cenv, Senv, Servers, Fd) ->
       [Class_c, Reason_c] = CAs,
       [_Class_s, Reason_s] = SAs,
       %% CONSTRAINT: Class_c = Class_s
-      eval({named, erlang, Class_c}, [Reason_c], [Reason_s], external, Servers, Fd);
+      eval({named, erlang, Class_c}, [Reason_c], [Reason_s], external, Servers, Fd, Options);
     match_fail ->
       [Cv] = CAs,
       [Sv] = SAs,
-      eval({named, erlang, error}, [{badmatch, Cv}], [{badmatch, Sv}], external, Servers, Fd);
+      eval({named, erlang, error}, [{badmatch, Cv}], [{badmatch, Sv}], external, Servers, Fd, Options);
     _ ->
       exception(error, {primop_not_supported, PrimOp})
   end;
 
 %% c_receive
-eval_expr({c_receive, _Anno, Clauses, Timeout, Action}, M, Cenv, Senv, Servers, Fd) ->
-  Timeout_ev = eval_expr(Timeout, M, Cenv, Senv, Servers, Fd),
+eval_expr({c_receive, _Anno, Clauses, Timeout, Action}, M, Cenv, Senv, Servers, Fd, Options) ->
+  Timeout_ev = eval_expr(Timeout, M, Cenv, Senv, Servers, Fd, Options),
   Timeout_c = get_concrete(Timeout_ev),
   Timeout_s = get_symbolic(Timeout_ev),
   true = check_timeout(Timeout_c, Timeout_s, Fd),
   Start = os:timestamp(),  %% Start time of timeout timer
   {messages, Mailbox} = erlang:process_info(self(), messages),
-  Message = find_message(Mailbox, Clauses, M, Cenv, Senv, Servers, Fd),
+  Message = find_message(Mailbox, Clauses, M, Cenv, Senv, Servers, Fd, Options),
   case Message of
     {Msg, Body, NCenv, NSenv, _Cnt} ->  %% Matched a message already in the mailbox
       receive Msg -> ok end,  %% Just consume the message
-      eval_expr(Body, M, NCenv, NSenv, Servers, Fd);
+      eval_expr(Body, M, NCenv, NSenv, Servers, Fd, Options);
     false ->  %% No mailbox message matched, thus need to enter a receive loop
       CurrMsgs = length(Mailbox),
-      find_message_loop(Clauses, Action, Timeout_c, Timeout_s, Start, CurrMsgs, M, Cenv, Senv, Servers, Fd)
+      find_message_loop(Clauses, Action, Timeout_c, Timeout_s, Start, CurrMsgs, M, Cenv, Senv, Servers, Fd, Options)
   end;
 
 %% c_seq
-eval_expr({c_seq, _Anno, Arg, Body}, M, Cenv, Senv, Servers, Fd) ->
-  _ = eval_expr(Arg, M, Cenv, Senv, Servers, Fd),
-  eval_expr(Body, M, Cenv, Senv, Servers, Fd);
+eval_expr({c_seq, _Anno, Arg, Body}, M, Cenv, Senv, Servers, Fd, Options) ->
+  _ = eval_expr(Arg, M, Cenv, Senv, Servers, Fd, Options),
+  eval_expr(Body, M, Cenv, Senv, Servers, Fd, Options);
 
 %% c_try
 %% Commented code: allow the exceptions to propagate
-eval_expr({c_try, _Anno, Arg, Vars, Body, Evars, Handler}, M, Cenv, Senv, Servers, Fd) ->
+eval_expr({c_try, _Anno, Arg, Vars, Body, Evars, Handler}, M, Cenv, Senv, Servers, Fd, Options) ->
   try
     Deg = length(Vars),
-    A_ev = eval_expr(Arg, M, Cenv, Senv, Servers, Fd),
+    A_ev = eval_expr(Arg, M, Cenv, Senv, Servers, Fd, Options),
     A_c = get_concrete(A_ev),
     A_s = get_concrete(A_ev),
     case Deg of
@@ -765,7 +768,7 @@ eval_expr({c_try, _Anno, Arg, Vars, Body, Evars, Handler}, M, Cenv, Senv, Server
     end,
     Ce = cuter_env:bind_parameters(CAs, Vars, Cenv),
     Se = cuter_env:bind_parameters(SAs, Vars, Senv),
-    eval_expr(Body, M, Ce, Se, Servers, Fd)
+    eval_expr(Body, M, Ce, Se, Servers, Fd, Options)
   catch
     Class:Reason ->
       Reason1 = unzip_one(Reason),
@@ -783,7 +786,7 @@ eval_expr({c_try, _Anno, Arg, Vars, Body, Evars, Handler}, M, Cenv, Senv, Server
         end,
       ECe = cuter_env:bind_parameters(Cs, Evars, Cenv),
       ESe = cuter_env:bind_parameters(Ss, Evars, Senv),
-      eval_expr(Handler, M, ECe, ESe, Servers, Fd)
+      eval_expr(Handler, M, ECe, ESe, Servers, Fd, Options)
   end;
 %%eval_expr({c_try, _Anno, Arg, Vars, Body, _Evars, _Handler}, M, Cenv, Senv, Servers, Fd) ->
 %%  Deg = length(Vars),
@@ -801,24 +804,24 @@ eval_expr({c_try, _Anno, Arg, Vars, Body, Evars, Handler}, M, Cenv, Senv, Server
 %%  eval_expr(Body, M, Ce, Se, Servers, Fd);
 
 %% c_tuple
-eval_expr({c_tuple, _Anno, Es}, M, Cenv, Senv, Servers, Fd) ->
-  Zes = [eval_expr(E, M, Cenv, Senv, Servers, Fd) || E <- Es],
+eval_expr({c_tuple, _Anno, Es}, M, Cenv, Senv, Servers, Fd, Options) ->
+  Zes = [eval_expr(E, M, Cenv, Senv, Servers, Fd, Options) || E <- Es],
   {Es_c, Es_s} = cuter_lib:unzip_with(fun to_tuple/1, Zes),
   Cv = list_to_tuple(Es_c),
   Sv = cuter_symbolic:make_tuple(Es_s, Cv, Fd),
   mk_result(Cv, Sv);
 
 %% c_values
-eval_expr({c_values, _Anno, Es}, M, Cenv, Senv, Servers, Fd) ->
+eval_expr({c_values, _Anno, Es}, M, Cenv, Senv, Servers, Fd, Options) ->
   Deg = length(Es),
-  Zes = [eval_expr(E, M, Cenv, Senv, Servers, Fd) || E <- Es],
+  Zes = [eval_expr(E, M, Cenv, Senv, Servers, Fd, Options) || E <- Es],
   {Es_c, Es_s} = cuter_lib:unzip_with(fun to_tuple/1, Zes),
   Cv = #valuelist{values=Es_c, degree=Deg},
   Sv = #valuelist{values=Es_s, degree=Deg},
   mk_result(Cv, Sv);
 
 %% c_var
-eval_expr({c_var, _Anno, Name}, _M, Cenv, Senv, _Servers, _Fd) when is_tuple(Name) ->
+eval_expr({c_var, _Anno, Name}, _M, Cenv, Senv, _Servers, _Fd, _Options) when is_tuple(Name) ->
   %% If Name is a function
   case cuter_env:get_value(Name, Cenv) of
     {ok, {letrec_func, {Mod, Def, E}}} ->
@@ -835,13 +838,13 @@ eval_expr({c_var, _Anno, Name}, _M, Cenv, Senv, _Servers, _Fd) when is_tuple(Nam
       R = {?FUNCTION_PREFIX, Name},
       mk_result(R, R)
   end;
-eval_expr({c_var, _Anno, Name}, _M, Cenv, Senv, _Servers, _Fd) ->
+eval_expr({c_var, _Anno, Name}, _M, Cenv, Senv, _Servers, _Fd, _Options) ->
   %% If it's a variable then return its value
   {ok, Cv} = cuter_env:get_value(Name, Cenv),
   {ok, Sv} = cuter_env:get_value(Name, Senv),
   mk_result(Cv, Sv);
 
-eval_expr(Cerl, _M, _Cenv, _Senv, _Servers, _Fd) ->
+eval_expr(Cerl, _M, _Cenv, _Senv, _Servers, _Fd, _Options) ->
   exception(error, {unknown_cerl, Cerl}).
 
 
@@ -950,16 +953,16 @@ exception(Class, Reason) ->
 %% Enters a loop waiting for a message that will match.
 %% Wraps calls to run_message_loop to check for timeout.
 %% --------------------------------------------------------
-find_message_loop(Clauses, Action, infinity, STimetout, Start, Msgs, M, Cenv, Senv, Servers, Fd) ->
-  run_message_loop(Clauses, Action, infinity, STimetout, Start, Msgs, M, Cenv, Senv, Servers, Fd);
-find_message_loop(Clauses, Action, CTimeout, STimeout, Start, Msgs, M, Cenv, Senv, Servers, Fd) ->
+find_message_loop(Clauses, Action, infinity, STimetout, Start, Msgs, M, Cenv, Senv, Servers, Fd, Options) ->
+  run_message_loop(Clauses, Action, infinity, STimetout, Start, Msgs, M, Cenv, Senv, Servers, Fd, Options);
+find_message_loop(Clauses, Action, CTimeout, STimeout, Start, Msgs, M, Cenv, Senv, Servers, Fd, Options) ->
   Now = os:timestamp(),
   Passed = timer:now_diff(Now, Start) / 1000,
   case Passed >= CTimeout of
     true ->
-      eval_expr(Action, M, Cenv, Senv, Servers, Fd);
+      eval_expr(Action, M, Cenv, Senv, Servers, Fd, Options);
     false ->
-      run_message_loop(Clauses, Action, CTimeout, STimeout, Start, Msgs, M, Cenv, Senv, Servers, Fd)
+      run_message_loop(Clauses, Action, CTimeout, STimeout, Start, Msgs, M, Cenv, Senv, Servers, Fd, Options)
   end.
 
 %% --------------------------------------------------------
@@ -967,23 +970,23 @@ find_message_loop(Clauses, Action, CTimeout, STimeout, Start, Msgs, M, Cenv, Sen
 %%
 %% Implements the actual waiting receive loop
 %% --------------------------------------------------------
-run_message_loop(Clauses, Action, CTimeout, STimeout, Start, Msgs, M, Cenv, Senv, Servers, Fd) ->
+run_message_loop(Clauses, Action, CTimeout, STimeout, Start, Msgs, M, Cenv, Senv, Servers, Fd, Options) ->
   erlang:yield(),
   {message_queue_len, CurrMsgs} = erlang:process_info(self(), message_queue_len),
   %% New messages will appended at the end of the mailbox
   case CurrMsgs > Msgs of
     false -> %% No new messages
-      find_message_loop(Clauses, Action, CTimeout, STimeout, Start, Msgs, M, Cenv, Senv, Servers, Fd);
+      find_message_loop(Clauses, Action, CTimeout, STimeout, Start, Msgs, M, Cenv, Senv, Servers, Fd, Options);
     true ->
       {messages, Mailbox} = erlang:process_info(self(), messages),
       NewMsgs = lists:nthtail(Msgs, Mailbox),
-      Message = find_message(NewMsgs, Clauses, M, Cenv, Senv, Servers, Fd),
+      Message = find_message(NewMsgs, Clauses, M, Cenv, Senv, Servers, Fd, Options),
       case Message of
         false ->
-          find_message_loop(Clauses, Action, CTimeout, STimeout, Start, CurrMsgs, M, Cenv, Senv, Servers, Fd);
+          find_message_loop(Clauses, Action, CTimeout, STimeout, Start, CurrMsgs, M, Cenv, Senv, Servers, Fd, Options);
         {Msg, Body, NCenv, NSenv, _Cnt} ->
           receive Msg -> ok end,  %% Just consume the matched message
-          eval_expr(Body, M, NCenv, NSenv, Servers, Fd)
+          eval_expr(Body, M, NCenv, NSenv, Servers, Fd, Options)
       end
   end.
 
@@ -993,16 +996,16 @@ run_message_loop(Clauses, Action, CTimeout, STimeout, Start, Msgs, M, Cenv, Senv
 %% Wraps calls to find_clause when trying to match 
 %% a message against a series of patterns
 %% --------------------------------------------------------
-find_message([], _Clauses, _M, _Cenv, _Senv, _Servers, _Fd) ->
+find_message([], _Clauses, _M, _Cenv, _Senv, _Servers, _Fd, _Options) ->
   false;
 
-find_message([Msg|Mailbox], Clauses, M, Cenv, Senv, Servers, Fd) ->
+find_message([Msg|Mailbox], Clauses, M, Cenv, Senv, Servers, Fd, Options) ->
   {LoggerFun, Msg1} = decode_msg(Msg, Fd),
-  case find_clause(Clauses, M, 'receive', get_concrete(Msg1), get_symbolic(Msg1), Cenv, Senv, Servers, Fd) of
+  case find_clause(Clauses, M, 'receive', get_concrete(Msg1), get_symbolic(Msg1), Cenv, Senv, Servers, Fd, Options) of
     false ->
-      find_message(Mailbox, Clauses, M, Cenv, Senv, Servers, Fd);
+      find_message(Mailbox, Clauses, M, Cenv, Senv, Servers, Fd, Options);
     {Body, NCenv, NSenv, Cnt} ->
-      log_successful_msg_match(LoggerFun),
+      conditional_log(fun log_successful_msg_match/1, [LoggerFun], Options),
       %% I can log the received Msg here
       {Msg, Body, NCenv, NSenv, Cnt}
   end.
@@ -1021,16 +1024,16 @@ log_successful_msg_match({withLogger, Fun}) -> Fun().
 %% compiler adds a catch all clause at the end of every
 %% case statement.
 %% --------------------------------------------------------
-find_clause(Clauses, M, Mode, Cv, Sv, Cenv, Senv, Servers, Fd) ->
-  find_clause(Clauses, M, Mode, Cv, Sv, Cenv, Senv, Servers, Fd, 1).
+find_clause(Clauses, M, Mode, Cv, Sv, Cenv, Senv, Servers, Fd, Options) ->
+  find_clause(Clauses, M, Mode, Cv, Sv, Cenv, Senv, Servers, Fd, 1, Options).
 
-find_clause([], _M, _Mode, _Cv, _Sv, _Cenv, _Senv, _Servers, _Fd, _Cnt) ->
+find_clause([], _M, _Mode, _Cv, _Sv, _Cenv, _Senv, _Servers, _Fd, _Cnt, _Options) ->
   false;
-find_clause([Cl|Cls], M, Mode, Cv, Sv, Cenv, Senv, Servers, Fd, Cnt) ->
-  Match = match_clause(Cl, M, Mode, Cv, Sv, Cenv, Senv, Servers,  Fd, Cnt),
+find_clause([Cl|Cls], M, Mode, Cv, Sv, Cenv, Senv, Servers, Fd, Cnt, Options) ->
+  Match = match_clause(Cl, M, Mode, Cv, Sv, Cenv, Senv, Servers,  Fd, Cnt, Options),
   case Match of
     false ->
-      find_clause(Cls, M, Mode, Cv, Sv, Cenv, Senv, Servers, Fd, Cnt+1);
+      find_clause(Cls, M, Mode, Cv, Sv, Cenv, Senv, Servers, Fd, Cnt+1, Options);
     {true, {_Body, _NCenv, _NSenv, Cnt} = Matched} ->
       Matched
   end.
@@ -1041,7 +1044,7 @@ find_clause([Cl|Cls], M, Mode, Cv, Sv, Cenv, Senv, Servers, Fd, Cnt) ->
 %% Match a pair of concrete & symbolic values against
 %% a specific clause (i.e. with patterns and guard)
 %% --------------------------------------------------------
-match_clause({c_clause, Anno, Pats, Guard, Body}, M, Mode, Cv, Sv, Cenv, Senv, Servers, Fd, Cnt) ->
+match_clause({c_clause, Anno, Pats, Guard, Body}, M, Mode, Cv, Sv, Cenv, Senv, Servers, Fd, Cnt, Options) ->
   case is_patlist_compatible(Pats, Cv) of
     false -> false;
     true ->
@@ -1057,7 +1060,7 @@ match_clause({c_clause, Anno, Pats, Guard, Body}, M, Mode, Cv, Sv, Cenv, Senv, S
       %% BitInfo is needed for parameterized bit-syntax patterns
       BitInfo = {M, Cenv, Senv},
       Ss_e = cuter_symbolic:ensure_list(Ss, length(Cs), Fd),
-      Match = pattern_match_all(Pats, BitInfo, Mode, Cs, Ss_e, Servers, Fd),
+      Match = pattern_match_all(Pats, BitInfo, Mode, Cs, Ss_e, Servers, Fd, Options),
       case Match of
         false -> false;
         {true, {CMs, SMs}} ->
@@ -1065,17 +1068,17 @@ match_clause({c_clause, Anno, Pats, Guard, Body}, M, Mode, Cv, Sv, Cenv, Senv, S
           Se = cuter_env:add_mappings_to_environment(SMs, Senv),
           %% Make silent guards
           Tags = cuter_cerl:get_tags(Anno),
-          Guard_ev = eval_expr(Guard, M, Ce, Se, Servers, Fd),
+          Guard_ev = eval_expr(Guard, M, Ce, Se, Servers, Fd, Options),
           try to_tuple(Guard_ev) of
             {true, SGv} ->
               %% CONSTRAINT: SGv is a True guard
               visit_tag(Servers#svs.code, Tags#tags.this),
-              cuter_log:log_guard(Fd, true, SGv, Tags#tags.next),
+              conditional_log(fun cuter_log:log_guard/4, [Fd, true, SGv, Tags#tags.next], Options),
               {true, {Body, Ce, Se, Cnt}};
             {false, SGv} ->
               %% CONSTRAINT: SGv is a False guard
               visit_tag(Servers#svs.code, Tags#tags.next),
-              cuter_log:log_guard(Fd, false, SGv, Tags#tags.this),
+              conditional_log(fun cuter_log:log_guard/4, [Fd, false, SGv, Tags#tags.this], Options),
               false
           catch
             error:_E -> false
@@ -1090,17 +1093,17 @@ match_clause({c_clause, Anno, Pats, Guard, Body}, M, Mode, Cv, Sv, Cenv, Senv, S
 %% patterns (short-circuited match)
 %% --------------------------------------------------------
 
-pattern_match_all(Pats, BitInfo, Mode, Cs, Ss, Servers, Fd) ->
-  pattern_match_all(Pats, BitInfo, Mode, Cs, Ss, [], [], Servers, Fd).
+pattern_match_all(Pats, BitInfo, Mode, Cs, Ss, Servers, Fd, Options) ->
+  pattern_match_all(Pats, BitInfo, Mode, Cs, Ss, [], [], Servers, Fd, Options).
 
-pattern_match_all([], _BitInfo, _Mode, [], [], CMaps, SMaps, _Servers, _Fd) ->
+pattern_match_all([], _BitInfo, _Mode, [], [], CMaps, SMaps, _Servers, _Fd, _Options) ->
   {true, {CMaps, SMaps}};
-pattern_match_all([P|Ps], BitInfo, Mode, [Cv|Cvs], [Sv|Svs], CMaps, SMaps, Servers, Fd) ->
-  Match = pattern_match(P, BitInfo, Mode, Cv, Sv, CMaps, SMaps, Servers, Fd),
+pattern_match_all([P|Ps], BitInfo, Mode, [Cv|Cvs], [Sv|Svs], CMaps, SMaps, Servers, Fd, Options) ->
+  Match = pattern_match(P, BitInfo, Mode, Cv, Sv, CMaps, SMaps, Servers, Fd, Options),
   case Match of
     false -> false;
     {true, {CMs, SMs}} ->
-      pattern_match_all(Ps, BitInfo, Mode, Cvs, Svs, CMs, SMs, Servers, Fd)
+      pattern_match_all(Ps, BitInfo, Mode, Cvs, Svs, CMs, SMs, Servers, Fd, Options)
   end.
 
 %% --------------------------------------------------------
@@ -1111,29 +1114,29 @@ pattern_match_all([P|Ps], BitInfo, Mode, [Cv|Cvs], [Sv|Svs], CMaps, SMaps, Serve
 %% --------------------------------------------------------
 
 %% AtomicLiteral pattern
-pattern_match({c_literal, Anno, LitVal}, _Bitinfo, _Mode, Cv, Sv, CMaps, SMaps, Servers, Fd) ->
+pattern_match({c_literal, Anno, LitVal}, _Bitinfo, _Mode, Cv, Sv, CMaps, SMaps, Servers, Fd, Options) ->
   Tags = cuter_cerl:get_tags(Anno),
   case LitVal =:= Cv of
     true ->
       %% CONSTRAINT: Sv =:= Litval
       visit_tag(Servers#svs.code, Tags#tags.this),
-      log_literal_match_success(Fd, LitVal, Sv, Tags#tags.next),
+      conditional_log(fun log_literal_match_success/4, [Fd, LitVal, Sv, Tags#tags.next], Options),
       {true, {CMaps, SMaps}};
     false ->
       %% CONSTRAINT: Sv =/= Litval
       visit_tag(Servers#svs.code, Tags#tags.next),
-      log_literal_match_failure(Fd, LitVal, Sv, Tags#tags.this),
+      conditional_log(fun log_literal_match_failure/4, [Fd, LitVal, Sv, Tags#tags.this], Options),
       false
   end;
 
 %% VariableName pattern
-pattern_match({c_var, _Anno, Name}, _BitInfo, _Mode, Cv, Sv, CMaps, SMaps, _Servers, _Fd) ->
+pattern_match({c_var, _Anno, Name}, _BitInfo, _Mode, Cv, Sv, CMaps, SMaps, _Servers, _Fd, _Options) ->
   CMs = [{Name, Cv}|CMaps],
   SMs = [{Name, Sv}|SMaps],
   {true, {CMs, SMs}};
 
 %% Tuple pattern
-pattern_match({c_tuple, Anno, Es}, BitInfo, Mode, Cv, Sv, CMaps, SMaps, Servers, Fd) when is_tuple(Cv) ->
+pattern_match({c_tuple, Anno, Es}, BitInfo, Mode, Cv, Sv, CMaps, SMaps, Servers, Fd, Options) when is_tuple(Cv) ->
   Ne = length(Es),
   Tags = cuter_cerl:get_tags(Anno),
   case tuple_size(Cv) =:= Ne of
@@ -1141,51 +1144,51 @@ pattern_match({c_tuple, Anno, Es}, BitInfo, Mode, Cv, Sv, CMaps, SMaps, Servers,
       Cv_l = tuple_to_list(Cv),
       %% CONSTRAINT: Sv is a tuple of Ne elements
       visit_tag(Servers#svs.code, Tags#tags.this),
-      cuter_log:log_tuple(Fd, sz, Sv, Ne, Tags#tags.next),
+      conditional_log(fun cuter_log:log_tuple/5, [Fd, sz, Sv, Ne, Tags#tags.next], Options),
       Sv_l = cuter_symbolic:tpl_to_list(Sv, Ne, Fd),
-      pattern_match_all(Es, BitInfo, Mode, Cv_l, Sv_l, CMaps, SMaps, Servers, Fd);
+      pattern_match_all(Es, BitInfo, Mode, Cv_l, Sv_l, CMaps, SMaps, Servers, Fd, Options);
     false ->
       %% CONSTRAINT: Sv is a tuple of not Ne elements
       visit_tag(Servers#svs.code, Tags#tags.next),
-      cuter_log:log_tuple(Fd, not_sz, Sv, Ne, Tags#tags.this),
+      conditional_log(fun cuter_log:log_tuple/5, [Fd, not_sz, Sv, Ne, Tags#tags.this], Options),
       false
   end;
-pattern_match({c_tuple, Anno, Es}, _BitInfo, _Mode, _Cv, Sv, _CMaps, _SMaps, Servers, Fd) ->
+pattern_match({c_tuple, Anno, Es}, _BitInfo, _Mode, _Cv, Sv, _CMaps, _SMaps, Servers, Fd, Options) ->
   Ne = length(Es),
   Tags = cuter_cerl:get_tags(Anno),
   %% CONSTRAINT: Sv is not a tuple
   visit_tag(Servers#svs.code, Tags#tags.next),
-  cuter_log:log_tuple(Fd, not_tpl, Sv, Ne, Tags#tags.this),
+  conditional_log(fun cuter_log:log_tuple/5, [Fd, not_tpl, Sv, Ne, Tags#tags.this], Options),
   false;
 
 %% List constructor pattern
-pattern_match({c_cons, Anno, _Hd, _Tl}, _BitInfo, _Mode, [], Sv, _CMaps, _SMaps, Servers, Fd) ->
+pattern_match({c_cons, Anno, _Hd, _Tl}, _BitInfo, _Mode, [], Sv, _CMaps, _SMaps, Servers, Fd, Options) ->
   Tags = cuter_cerl:get_tags(Anno),
   %% CONSTRAINT: Sv is an empty list
   visit_tag(Servers#svs.code, Tags#tags.next),
-  cuter_log:log_list(Fd, empty, Sv, Tags#tags.this),
+  conditional_log(fun cuter_log:log_list/4, [Fd, empty, Sv, Tags#tags.this], Options),
   false;
-pattern_match({c_cons, Anno, Hd, Tl}, BitInfo, Mode, [Cv|Cvs], Sv, CMaps, SMaps, Servers, Fd) ->
+pattern_match({c_cons, Anno, Hd, Tl}, BitInfo, Mode, [Cv|Cvs], Sv, CMaps, SMaps, Servers, Fd, Options) ->
   Tags = cuter_cerl:get_tags(Anno),
   %% CONSTRAINT: S is a non empty list
   visit_tag(Servers#svs.code, Tags#tags.this),
-  cuter_log:log_list(Fd, nonempty, Sv, Tags#tags.next),
+  conditional_log(fun cuter_log:log_list/4, [Fd, nonempty, Sv, Tags#tags.next], Options),
   Sv_h = cuter_symbolic:head(Sv, Fd),
   Sv_t = cuter_symbolic:tail(Sv, Fd),
-  case pattern_match(Hd, BitInfo, Mode, Cv, Sv_h, CMaps, SMaps, Servers, Fd) of
+  case pattern_match(Hd, BitInfo, Mode, Cv, Sv_h, CMaps, SMaps, Servers, Fd, Options) of
     false -> false;
-    {true, {CMs, SMs}} -> pattern_match(Tl, BitInfo, Mode, Cvs, Sv_t, CMs, SMs, Servers, Fd)
+    {true, {CMs, SMs}} -> pattern_match(Tl, BitInfo, Mode, Cvs, Sv_t, CMs, SMs, Servers, Fd, Options)
   end;
-pattern_match({c_cons, Anno, _Hd, _Tl}, _BitInfo, _Mode, _Cv, Sv, _CMaps, _SMaps, Servers, Fd) ->
+pattern_match({c_cons, Anno, _Hd, _Tl}, _BitInfo, _Mode, _Cv, Sv, _CMaps, _SMaps, Servers, Fd, Options) ->
   Tags = cuter_cerl:get_tags(Anno),
   %% CONSTRAINT: Sv is not a list
   visit_tag(Servers#svs.code, Tags#tags.next),
-  cuter_log:log_list(Fd, not_lst, Sv, Tags#tags.this),
+  conditional_log(fun cuter_log:log_list/4, [Fd, not_lst, Sv, Tags#tags.this], Options),
   false;
 
 %% Alias pattern
-pattern_match({c_alias, _Anno, Var, Pat}, BitInfo, Mode, Cv, Sv, CMaps, SMaps, Servers, Fd) ->
-  Match = pattern_match(Pat, BitInfo, Mode, Cv, Sv, CMaps, SMaps, Servers, Fd),
+pattern_match({c_alias, _Anno, Var, Pat}, BitInfo, Mode, Cv, Sv, CMaps, SMaps, Servers, Fd, Options) ->
+  Match = pattern_match(Pat, BitInfo, Mode, Cv, Sv, CMaps, SMaps, Servers, Fd, Options),
   case Match of
     false -> false;
     {true, {CMs, SMs}} ->
@@ -1196,43 +1199,43 @@ pattern_match({c_alias, _Anno, Var, Pat}, BitInfo, Mode, Cv, Sv, CMaps, SMaps, S
   end;
 
 %% Binary pattern
-pattern_match({c_binary, Anno, Segments}, BitInfo, Mode, Cv, Sv, CMaps, SMaps, Servers, Fd) ->
-  bit_pattern_match(Anno, Segments, BitInfo, Mode, Cv, Sv, CMaps, SMaps, Servers, Fd).
+pattern_match({c_binary, Anno, Segments}, BitInfo, Mode, Cv, Sv, CMaps, SMaps, Servers, Fd, Options) ->
+  bit_pattern_match(Anno, Segments, BitInfo, Mode, Cv, Sv, CMaps, SMaps, Servers, Fd, Options).
 
 %% --------------------------------------------------------
 %% bit_pattern_match
 %% 
 %% --------------------------------------------------------
 
-bit_pattern_match(BinAnno, [], _BitInfo, _Mode, <<>>, Sv, CMaps, SMaps, Servers, Fd) ->
+bit_pattern_match(BinAnno, [], _BitInfo, _Mode, <<>>, Sv, CMaps, SMaps, Servers, Fd, Options) ->
   %% CONSTRAINT: Sv =:= <<>>
   Tags = cuter_cerl:get_tags(BinAnno),
   visit_tag(Servers#svs.code, Tags#tags.this),
-  cuter_log:log_equal(Fd, true, <<>>, Sv, Tags#tags.next),
+  conditional_log(fun cuter_log:log_equal/5, [Fd, true, <<>>, Sv, Tags#tags.next], Options),
   {true, {CMaps, SMaps}};
-bit_pattern_match(BinAnno, [], _BitInfo, _Mode, _Cv, Sv, _CMaps, _SMaps, Servers, Fd) ->
+bit_pattern_match(BinAnno, [], _BitInfo, _Mode, _Cv, Sv, _CMaps, _SMaps, Servers, Fd, Options) ->
   %% CONSTRAINT: Sv =/= <<>>
   Tags = cuter_cerl:get_tags(BinAnno),
   visit_tag(Servers#svs.code, Tags#tags.next),
-  cuter_log:log_equal(Fd, false, <<>>, Sv, Tags#tags.this),
+  conditional_log(fun cuter_log:log_equal/5, [Fd, false, <<>>, Sv, Tags#tags.this], Options),
   false;
 
-bit_pattern_match(BinAnno, [{c_bitstr, Anno, {c_literal, _, LVal}, Sz, Unit, Tp, Fgs}|Bs], {M, Cenv, Senv} = Bnfo, Mode, Cv, Sv, CMaps, SMaps, Svs, Fd) ->
-  Size_ev = eval_expr(Sz, M, Cenv, Senv, Svs, Fd),
-  Unit_ev = eval_expr(Unit, M, Cenv, Senv, Svs, Fd),
-  Type_ev = eval_expr(Tp, M, Cenv, Senv, Svs, Fd),
-  Flags_ev = eval_expr(Fgs, M, Cenv, Senv, Svs, Fd),
+bit_pattern_match(BinAnno, [{c_bitstr, Anno, {c_literal, _, LVal}, Sz, Unit, Tp, Fgs}|Bs], {M, Cenv, Senv} = Bnfo, Mode, Cv, Sv, CMaps, SMaps, Svs, Fd, Options) ->
+  Size_ev = eval_expr(Sz, M, Cenv, Senv, Svs, Fd, Options),
+  Unit_ev = eval_expr(Unit, M, Cenv, Senv, Svs, Fd, Options),
+  Type_ev = eval_expr(Tp, M, Cenv, Senv, Svs, Fd, Options),
+  Flags_ev = eval_expr(Fgs, M, Cenv, Senv, Svs, Fd, Options),
   Size_c = get_concrete(Size_ev),
   Size_s = get_symbolic(Size_ev),
   Enc_s = {Size_s, get_symbolic(Unit_ev), get_symbolic(Type_ev), get_symbolic(Flags_ev)},
   Tags = cuter_cerl:get_tags(Anno),
   %% Log constraints on negative sizes before matching.
-  log_bitstr_neg_size(Size_c, Size_s, Fd),
+  conditional_log(fun log_bitstr_neg_size/3, [Size_c, Size_s, Fd], Options),
   try cuter_binlib:match_bitstring_const(LVal, Size_c, get_concrete(Unit_ev), get_concrete(Type_ev), get_concrete(Flags_ev), Cv) of
     Rest_c ->
       visit_tag(Svs#svs.code, Tags#tags.this),
       Rest_s = cuter_symbolic:match_bitstring_const_true(LVal, Enc_s, Sv, Rest_c, Size_c, Tags#tags.next, Fd),
-      bit_pattern_match(BinAnno, Bs, Bnfo, Mode,  Rest_c, Rest_s, CMaps, SMaps, Svs, Fd)
+      bit_pattern_match(BinAnno, Bs, Bnfo, Mode,  Rest_c, Rest_s, CMaps, SMaps, Svs, Fd, Options)
   catch
     error:_e ->
       visit_tag(Svs#svs.code, Tags#tags.next),
@@ -1240,17 +1243,17 @@ bit_pattern_match(BinAnno, [{c_bitstr, Anno, {c_literal, _, LVal}, Sz, Unit, Tp,
       false
   end;
 
-bit_pattern_match(BinAnno, [{c_bitstr, Anno, {c_var, _, VarName}, Sz, Unit, Tp, Fgs}|Bs], {M, Cenv, Senv}, Mode, Cv, Sv, CMaps, SMaps, Svs, Fd) ->
-  Size_ev = eval_expr(Sz, M, Cenv, Senv, Svs, Fd),
-  Unit_ev = eval_expr(Unit, M, Cenv, Senv, Svs, Fd),
-  Type_ev = eval_expr(Tp, M, Cenv, Senv, Svs, Fd),
-  Flags_ev = eval_expr(Fgs, M, Cenv, Senv, Svs, Fd),
+bit_pattern_match(BinAnno, [{c_bitstr, Anno, {c_var, _, VarName}, Sz, Unit, Tp, Fgs}|Bs], {M, Cenv, Senv}, Mode, Cv, Sv, CMaps, SMaps, Svs, Fd, Options) ->
+  Size_ev = eval_expr(Sz, M, Cenv, Senv, Svs, Fd, Options),
+  Unit_ev = eval_expr(Unit, M, Cenv, Senv, Svs, Fd, Options),
+  Type_ev = eval_expr(Tp, M, Cenv, Senv, Svs, Fd, Options),
+  Flags_ev = eval_expr(Fgs, M, Cenv, Senv, Svs, Fd, Options),
   Size_c = get_concrete(Size_ev),
   Size_s = get_symbolic(Size_ev),
   Enc_s = {Size_s, get_symbolic(Unit_ev), get_symbolic(Type_ev), get_symbolic(Flags_ev)},
   Tags = cuter_cerl:get_tags(Anno),
   %% Log constraints on negative sizes before matching.
-  log_bitstr_neg_size(Size_c, Size_s, Fd),
+  conditional_log(fun log_bitstr_neg_size/3, [Size_c, Size_s, Fd], Options),
   try cuter_binlib:match_bitstring_var(Size_c, get_concrete(Unit_ev), get_concrete(Type_ev), get_concrete(Flags_ev), Cv) of
     {X_c, Rest_c} ->
       visit_tag(Svs#svs.code, Tags#tags.this),
@@ -1266,7 +1269,7 @@ bit_pattern_match(BinAnno, [{c_bitstr, Anno, {c_var, _, VarName}, Sz, Unit, Tp, 
         end,
       NCenv = cuter_env:add_binding(VarName, X_c, Cenv),
       NSenv = cuter_env:add_binding(VarName, X_s, Senv),
-      bit_pattern_match(BinAnno, Bs, {M, NCenv, NSenv}, Mode, Rest_c, Rest_s, CMs, SMs, Svs, Fd)
+      bit_pattern_match(BinAnno, Bs, {M, NCenv, NSenv}, Mode, Rest_c, Rest_s, CMs, SMs, Svs, Fd, Options)
   catch
     error:_E ->
       visit_tag(Svs#svs.code, Tags#tags.next),
@@ -1280,18 +1283,18 @@ bit_pattern_match(BinAnno, [{c_bitstr, Anno, {c_var, _, VarName}, Sz, Unit, Tp, 
 %% --------------------------------------------------------
 
 %% Create a Closure of a local function
-create_closure(M, F, Arity, local, Servers, Fd) ->
+create_closure(M, F, Arity, local, Servers, Fd, Options) ->
   Mfa = {NM, _NF, NA} = cuter_mock:maybe_override_mfa({M, F, Arity}),
   %% Module is already loaded since create_closure is called by eval_expr.
   {ok, Kfun} = get_kfun(Mfa, Servers),
   Code = cuter_cerl:kfun_code(Kfun),
   Cenv = cuter_env:new_environment(),
   Senv = cuter_env:new_environment(),
-  make_fun(Code#c_fun.vars, Code#c_fun.body, NM, NA, Cenv, Senv, Servers, Fd);
+  make_fun(Code#c_fun.vars, Code#c_fun.body, NM, NA, Cenv, Senv, Servers, Fd, Options);
 
 %% Create a Closure when the MFA is a function bound in a letrec
-create_closure(M, _F, Arity, {letrec_func, {Def, Cenv, Senv}}, Servers, Fd) ->
-  make_fun(Def#c_fun.vars, Def#c_fun.body, M, Arity, Cenv, Senv, Servers, Fd).
+create_closure(M, _F, Arity, {letrec_func, {Def, Cenv, Senv}}, Servers, Fd, Options) ->
+  make_fun(Def#c_fun.vars, Def#c_fun.body, M, Arity, Cenv, Senv, Servers, Fd, Options).
 
 %% --------------------------------------------------------
 %% Create closures.
@@ -1304,7 +1307,7 @@ create_closure(M, _F, Arity, {letrec_func, {Def, Cenv, Senv}}, Servers, Fd) ->
 
 %% Creates a closure from Core Erlang code. 
 %% The interpreted code is wrapped in a call to eval_expr.
-make_fun(Vars, Body, Mod, Arity, Cenv, Senv, Servers, Fd) ->
+make_fun(Vars, Body, Mod, Arity, Cenv, Senv, Servers, Fd, Options) ->
   Creator = self(),
   LambdaS = cuter_symbolic:fresh_lambda(Arity, Fd),
   add_to_created_closure(LambdaS),
@@ -1312,94 +1315,94 @@ make_fun(Vars, Body, Mod, Arity, Cenv, Senv, Servers, Fd) ->
     case Arity of
       0 ->
         fun() ->
-          make_fun_h1(Mod, [], Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd)
+          make_fun_h1(Mod, [], Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd, Options)
         end;
       1 ->
         fun(A) ->
           Args = [A],
-          make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd)
+          make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd, Options)
         end;
       2 ->
         fun(A, B) ->
           Args = [A, B],
-          make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd)
+          make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd, Options)
         end;
       3 ->
         fun(A, B, C) ->
           Args = [A, B, C],
-          make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd)
+          make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd, Options)
         end;
       4 ->
         fun(A, B, C, D) ->
           Args = [A, B, C, D],
-          make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd)
+          make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd, Options)
         end;
       5 ->
         fun(A, B, C, D, E) ->
           Args = [A, B, C, D, E],
-          make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd)
+          make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd, Options)
         end;
       6 ->
         fun(A, B, C, D, E, F) ->
           Args = [A, B, C, D, E, F],
-          make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd)
+          make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd, Options)
         end;
       7 ->
         fun(A, B, C, D, E, F, G) ->
           Args = [A, B, C, D, E, F, G],
-          make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd)
+          make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd, Options)
         end;
       8 ->
         fun(A, B, C, D, E, F, G, H) ->
           Args = [A, B, C, D, E, F, G, H],
-          make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd)
+          make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd, Options)
         end;
       9 ->
         fun(A, B, C, D, E, F, G, H, I) ->
           Args = [A, B, C, D, E, F, G, H, I],
-          make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd)
+          make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd, Options)
         end;
       10 ->
         fun(A, B, C, D, E, F, G, H, I, J) ->
           Args = [A, B, C, D, E, F, G, H, I, J],
-          make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd)
+          make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd, Options)
         end;
       11 ->
         fun(A, B, C, D, E, F, G, H, I, J, K) ->
           Args = [A, B, C, D, E, F, G, H, I, J, K],
-          make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd)
+          make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd, Options)
         end;
       12 ->
         fun(A, B, C, D, E, F, G, H, I, J, K, L) ->
           Args = [A, B, C, D, E, F, G, H, I, J, K, L],
-          make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd)
+          make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd, Options)
         end;
       13 ->
         fun(A, B, C, D, E, F, G, H, I, J, K, L, M) ->
           Args = [A, B, C, D, E, F, G, H, I, J, K, L, M],
-          make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd)
+          make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd, Options)
         end;
       14 ->
         fun(A, B, C, D, E, F, G, H, I, J, K, L, M, N) ->
           Args = [A, B, C, D, E, F, G, H, I, J, K, L, M, N],
-          make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd)
+          make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd, Options)
         end;
       15 ->
         fun(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) ->
           Args = [A, B, C, D, E, F, G, H, I, J, K, L, M, N, O],
-          make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd)
+          make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, Fd, Options)
         end;
       _ ->
         exception(error, {over_lambda_fun_argument_limit, Arity})
     end,
   mk_result(LambdaC, LambdaS).
 
-make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, FileDescr) ->
+make_fun_h1(Mod, Args, Servers, Vars, Body, Cenv, Senv, Creator, LambdaS, FileDescr, Options) ->
   {Ce, Se, SAs} = register_new_environments(Args, Vars, Cenv, Senv),
   NSvs = validate_servers(Servers),
   Fd = validate_file_descriptor(NSvs#svs.monitor, Creator, FileDescr),
-  Ret = eval_expr(Body, Mod, Ce, Se, NSvs, Fd),
-  cuter_log:log_evaluated_closure(Fd, LambdaS, SAs, get_symbolic(Ret)),
+  Ret = eval_expr(Body, Mod, Ce, Se, NSvs, Fd, Options),
+  conditional_log(fun cuter_log:log_evaluated_closure/4, [Fd, LambdaS, SAs, get_symbolic(Ret)], Options),
   Ret.
 
 register_new_environments([], _Vars, Cenv, Senv) ->
@@ -1413,7 +1416,7 @@ register_new_environments(Args, Vars, Cenv, Senv) ->
 
 %% Creates a closure from an MFA (emulates the behaviour
 %% of erlang:make_fun/3) 
-make_fun(Mod, Func, Arity, Servers, Fd) ->
+make_fun(Mod, Func, Arity, Servers, Fd, Options) ->
   Creator = self(),
   LambdaS = cuter_symbolic:fresh_lambda(Arity, Fd),
   add_to_created_closure(LambdaS),
@@ -1421,94 +1424,94 @@ make_fun(Mod, Func, Arity, Servers, Fd) ->
     case Arity of
       0 ->
         fun() ->
-          make_fun_h(Mod, Func, [], Servers, Creator, LambdaS, Fd)
+          make_fun_h(Mod, Func, [], Servers, Creator, LambdaS, Fd, Options)
         end;
       1 ->
         fun(A) ->
           Args = [A],
-          make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, Fd)
+          make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, Fd, Options)
         end;
       2 ->
         fun(A, B) ->
           Args = [A, B],
-          make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, Fd)
+          make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, Fd, Options)
         end;
       3 ->
         fun(A, B, C) ->
           Args = [A, B, C],
-          make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, Fd)
+          make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, Fd, Options)
         end;
       4 ->
         fun(A, B, C, D) ->
           Args = [A, B, C, D],
-          make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, Fd)
+          make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, Fd, Options)
         end;
       5 ->
         fun(A, B, C, D, E) ->
           Args = [A, B, C, D, E],
-          make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, Fd)
+          make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, Fd, Options)
         end;
       6 ->
         fun(A, B, C, D, E, F) ->
           Args = [A, B, C, D, E, F],
-          make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, Fd)
+          make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, Fd, Options)
         end;
       7 ->
         fun(A, B, C, D, E, F, G) ->
           Args = [A, B, C, D, E, F, G],
-          make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, Fd)
+          make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, Fd, Options)
         end;
       8 ->
         fun(A, B, C, D, E, F, G, H) ->
           Args = [A, B, C, D, E, F, G, H],
-          make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, Fd)
+          make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, Fd, Options)
         end;
       9 ->
         fun(A, B, C, D, E, F, G, H, I) ->
           Args = [A, B, C, D, E, F, G, H, I],
-          make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, Fd)
+          make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, Fd, Options)
         end;
       10 ->
         fun(A, B, C, D, E, F, G, H, I, J) ->
           Args = [A, B, C, D, E, F, G, H, I, J],
-          make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, Fd)
+          make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, Fd, Options)
         end;
       11 ->
         fun(A, B, C, D, E, F, G, H, I, J, K) ->
           Args = [A, B, C, D, E, F, G, H, I, J, K],
-          make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, Fd)
+          make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, Fd, Options)
         end;
       12 ->
         fun(A, B, C, D, E, F, G, H, I, J, K, L) ->
           Args = [A, B, C, D, E, F, G, H, I, J, K, L],
-          make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, Fd)
+          make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, Fd, Options)
         end;
       13 ->
         fun(A, B, C, D, E, F, G, H, I, J, K, L, M) ->
           Args = [A, B, C, D, E, F, G, H, I, J, K, L, M],
-          make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, Fd)
+          make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, Fd, Options)
         end;
       14 ->
         fun(A, B, C, D, E, F, G, H, I, J, K, L, M, N) ->
           Args = [A, B, C, D, E, F, G, H, I, J, K, L, M, N],
-          make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, Fd)
+          make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, Fd, Options)
         end;
       15 ->
         fun(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) ->
           Args = [A, B, C, D, E, F, G, H, I, J, K, L, M, N, O],
-          make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, Fd)
+          make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, Fd, Options)
         end;
       _ ->
         exception(error, {over_lambda_fun_argument_limit, Arity})
     end,
   mk_result(LambdaC, LambdaS).
 
-make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, FileDescr) ->
+make_fun_h(Mod, Func, Args, Servers, Creator, LambdaS, FileDescr, Options) ->
   {CAs, SAs} = unzip_args(Args), %% If Args =:= [] then unzip_args([]) will return {[], []}
   NSvs = validate_servers(Servers),
   Fd = validate_file_descriptor(NSvs#svs.monitor, Creator, FileDescr),
-  Ret = eval({named, Mod, Func}, CAs, SAs, external, NSvs, Fd),
-  cuter_log:log_evaluated_closure(Fd, LambdaS, SAs, get_symbolic(Ret)),
+  Ret = eval({named, Mod, Func}, CAs, SAs, external, NSvs, Fd, Options),
+  conditional_log(fun cuter_log:log_evaluated_closure/4, [Fd, LambdaS, SAs, get_symbolic(Ret)], Options),
   Ret.
 
 %% --------------------------------------------------------
@@ -1946,4 +1949,12 @@ log_bistr_type_mismatch(Cv, Sv, Type, Fd) ->
         _ ->
           throw({unknown_bitstr_type, Type})
       end
+  end.
+
+conditional_log(LogFun, Args, Options) ->
+  case maps:get(constraintLogging, Options) of
+    true ->
+      apply(LogFun, Args);
+    false ->
+      ok
   end.


### PR DESCRIPTION
The way to "prune" redundant paths is to disable constraint logging during the evaluation of the sub-trees in the AST that we deem "safe".

This PR adds an options parameter to the evaluator function of the interpreter that encapsulates this flag (and potentially other useful ones for features in the future).

The logic for flipping the flag will be part of a follow-up PR; this just introduces the options.