### PR TITLE
Upgrade mypy version (for python 3.9)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 attrs==19.3.0
-mypy==0.770
+mypy==0.780
 mypy-protobuf==1.20
 parsimonious==0.8.1
 protobuf==3.17.0


### PR DESCRIPTION
When using Python 3.9 (of current Debian stable) one of the unit tests fails due to requiring a newer version of mypy.