### PR TITLE
Record PIDs and refs in log traces

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -110,6 +110,7 @@ FTEST_MODULES = \
 	no_debug_info \
 	collection \
 	funs \
+	pingpong \
 	sum \
 	reduce_search_space
 

--- a/priv/cuter_common.py
+++ b/priv/cuter_common.py
@@ -249,6 +249,20 @@ def get_alias(t):
     assert is_alias(t)
     return t.value
 
+def is_pid(t):
+    """
+    Parameters
+        t : ErlangTerm
+    """
+    return t.type == ErlangTerm.PID
+
+def get_pid(t):
+    """
+    Parameters
+        t : ErlangTerm
+    """
+    return t.value
+
 def get_shared(t):
     """
     Parameters

--- a/priv/cuter_print.py
+++ b/priv/cuter_print.py
@@ -62,6 +62,9 @@ def pretty(d):
     if cc.is_bitstring(d):
       bits = map(lambda x: 1 if x else 0, cc.get_bits(d))
       return "<<%s>>" % pretty_list(bits)
+    # PID
+    if cc.is_pid(d):
+      return str(cc.get_pid(d))
   except KeyError:
     pass
   return str(d)

--- a/priv/cuter_smt.py
+++ b/priv/cuter_smt.py
@@ -164,10 +164,10 @@ class ErlangSMT(cgs.AbstractErlangSolver):
 		elif cc.is_pid(data):
 			v = cc.get_pid(data)
 			v = int(v.replace("<", "").replace(">", "").replace(".", ""))
-			# Represent a PID as an int. We do not expect the solver to
-			# be able to reason about it, but just handle it if it
-			# appears in a term.
-            # e.g. A process sends the message {self(), 42} to another process.
+			# Represent a PID as an int.  We do not expect the solver
+			# to be able to reason about it, but just handle it if it
+			# appears in a term (e.g., when process sends the message
+			# {self(), 42} to another process).
 			return ["int", build_int(v)]
 		clg.debug_info("decoding failed: " + str(data))
 		assert False

--- a/priv/cuter_smt.py
+++ b/priv/cuter_smt.py
@@ -161,6 +161,14 @@ class ErlangSMT(cgs.AbstractErlangSolver):
 			return ["str", build_slist(cc.get_bits(data))]
 		elif cc.is_alias(data):
 			return self.decode(shared[cc.get_alias(data)], shared)
+		elif cc.is_pid(data):
+			v = cc.get_pid(data)
+			v = int(v.replace("<", "").replace(">", "").replace(".", ""))
+			# Represent a PID as an int. We do not expect the solver to
+			# be able to reason about it, but just handle it if it
+			# appears in a term.
+            # e.g. A process sends the message {self(), 42} to another process.
+			return ["int", build_int(v)]
 		clg.debug_info("decoding failed: " + str(data))
 		assert False
 

--- a/src/cuter_serial.erl
+++ b/src/cuter_serial.erl
@@ -185,16 +185,17 @@ encode_term(T, Seen) when is_tuple(T) ->
   Subterms = [encode_maybe_shared_term(X, Seen) || X <- Ts],
   #'ErlangTerm'{type='TUPLE', subterms=Subterms};
 %%%
-%%% TODO: Uncomment out these clauses when it is decided how to
-%%% properly handle pids and refs.  Also, make sure that the
-%%% corresponding unit tests are re-enabled.
+%%% We encode PIDs and refs with the assumption that the solver
+%%% cannot reason about them. We do not expect to receive them
+%%% as values that will exercise the unit under test, hence
+%%% we do not implement the decode_term equivalent.
 %%%
 %% %% pid
-%% encode_term(Pid, _Seen) when is_pid(Pid) ->
-%%   #'ErlangTerm'{type='PID', value=pid_to_list(Pid)};
+ encode_term(Pid, _Seen) when is_pid(Pid) ->
+   #'ErlangTerm'{type='PID', value=pid_to_list(Pid)};
 %% %% reference
-%% encode_term(Ref, _Seen) when is_reference(Ref) ->
-%%   #'ErlangTerm'{type='REFERENCE', value=erlang:ref_to_list(Ref)};
+ encode_term(Ref, _Seen) when is_reference(Ref) ->
+   #'ErlangTerm'{type='REFERENCE', value=erlang:ref_to_list(Ref)};
 %% bitstring & binary
 encode_term(Ref, _Seen) when is_bitstring(Ref) ->
   Bits = encode_bitstring(Ref),

--- a/test/ftest/src/pingpong.erl
+++ b/test/ftest/src/pingpong.erl
@@ -1,0 +1,24 @@
+-module(pingpong).
+-export([start/1, ping/2, pong/0]).
+
+-spec start(integer()) -> ok.
+start(N) ->
+    PongPid = spawn(?MODULE, pong, []),
+    ping(PongPid, N).
+
+ping(PongPid, N) ->
+    PongPid ! {ping, self(), N},
+    receive
+        {pong, RN} ->
+            case RN of
+                42 -> throw({error, simulated_exception});
+                _ -> ok
+            end
+    end,
+    ok.
+
+pong() ->
+    receive
+        {ping, SenderPid, N} ->
+            SenderPid ! {pong, N + 1}
+    end.

--- a/test/ftests.json
+++ b/test/ftests.json
@@ -1251,6 +1251,21 @@
               "UNSAT": 6
             },
             "skip": false
+        },
+        {
+            "module": "pingpong",
+            "function": "start",
+            "args": "[17]",
+            "depth": "25",
+            "errors": true,
+            "arity": 1,
+            "solutions": [
+                "[41]"
+            ],
+            "bifs": [
+                "erlang:self/0"
+            ],
+            "skip": false
         }
     ]
 }


### PR DESCRIPTION
Currently, we were dropping log entries with PIDs and refs, which led to missing critical information for certain programs:
- when a process would send a message like `{self(), 42}`
- when a process would consume a message from the mailbox

The solver does not need to reason about these types, but just "tolerate" them. We do not expect that they will be passed as arguments to the unit under test, but they are being generated as values during the execution of the program.