### PR TITLE
Fix the check for Python version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -56,8 +56,8 @@ fi
 AC_SUBST(PYTHON_PATH)
 
 cat > test_python.py <<EOF
-from sys import version
-if version < "3.6":
+import sys
+if sys.version_info < (3,6):
    exit(1)
 exit(0)
 EOF


### PR DESCRIPTION
The check we had for the Python3 version was broken. It performed string comparison, so "3.11.2" was considered smaller than "3.6" and configure failed.  Fix this by properly parsing the version and properly comparing against version 3.6.